### PR TITLE
fix: fixed broken links

### DIFF
--- a/dial-cookbook/docker-compose.yml
+++ b/dial-cookbook/docker-compose.yml
@@ -4,6 +4,10 @@ version: '1'
 services:
   echo:
     build: ../dial-sdk/examples/echo
+  image-size:
+    build: ../dial-sdk/examples/image_size
+  render-text:
+    build: ../dial-sdk/examples/render_text
   core:
     ports:
       - "8080:8080"

--- a/dial-cookbook/examples/how_to_call_image_to_text_applications.ipynb
+++ b/dial-cookbook/examples/how_to_call_image_to_text_applications.ipynb
@@ -4,21 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# How to call text-to-image DIAL applications\n",
+    "# How to call image-to-text DIAL applications\n",
     "\n",
-    "This notebook covers how to call text-to-image applications via [DIAL API chat/completions](https://epam-rail.com/dial_api#/paths/~1openai~1deployments~1%7BDeployment%20Name%7D~1chat~1completions/post) call.\n",
+    "This notebook covers how to call image-to-text applications via [DIAL API chat/completions](https://epam-rail.com/dial_api#/paths/~1openai~1deployments~1%7BDeployment%20Name%7D~1chat~1completions/post) call.\n",
     "\n",
     "**DIAL application** is a general term, which encompasses model adapters and application with custom logic.\n",
     "\n",
-    "DIAL currently supports a few text-to-image model adapters:\n",
+    "DIAL currently supports a few image-to-text model adapters:\n",
     "\n",
-    "* [DALL-E-3](https://github.com/epam/ai-dial-adapter-openai/)\n",
-    "* [Google Imagen](https://github.com/epam/ai-dial-adapter-vertexai/)\n",
-    "* [Stability diffusion](https://github.com/epam/ai-dial-adapter-bedrock/)\n",
+    "* [GPT4-Vision](https://github.com/epam/ai-dial-adapter-openai/)\n",
+    "* [Gemini Pro Vision](https://github.com/epam/ai-dial-adapter-vertexai/)\n",
     "\n",
-    "These models follow the same pattern of usage - they take a last user message as a prompt for image generation and return the generated image in the response.\n",
+    "These models follow the same pattern of usage - they take the chat history of interactions between user and model, some of the user messages may contain image attachments, which the model takes into account when it generates the response.\n",
     "\n",
-    "As a simple proxy for these models we'll use an application which prints the given user prompt as an image.\n",
+    "The typical use case is to attach an image to a message and ask the model to describe it in the same message.\n",
+    "\n",
+    "As a simple proxy for these models we'll use an application which take an image in attachment and returns its width and height dimensions.\n",
     "\n",
     "## Setup\n",
     "\n",
@@ -27,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -44,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,12 +58,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Run docker compose in a separate terminal to start the DIAL Core server locally along with the `image-size` application.\n",
+    "Run docker compose in a separate terminal to start the DIAL Core server locally along with the `render-text` application.\n",
     "\n",
-    "`image-size` is a simple image-to-text application which returns dimensions of an attached image.\n",
+    "The `render-text` is a simple text-to-image application which prints the user prompt as an image. We use it as a stand-in for the more complex text-to-image models.\n",
     "\n",
     "```sh\n",
-    "(cd ..; docker compose up core image-size)\n",
+    "(cd ..; docker compose up core render-text)\n",
     "```"
    ]
   },
@@ -75,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,12 +89,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Helpers to read images from disk and display images in the notebook:"
+    "Helpers to display images in the notebook:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,12 +105,7 @@
     "\n",
     "def display_base64_image(image_base64):\n",
     "    image_binary = base64.b64decode(image_base64)\n",
-    "    display(IPImage(data=image_binary))\n",
-    "\n",
-    "def read_image_base64(image_path: str) -> str:\n",
-    "    with open(image_path, \"rb\") as image_file:\n",
-    "        image_base64 = base64.b64encode(image_file.read()).decode()\n",
-    "    return image_base64\n"
+    "    display(IPImage(data=image_binary))"
    ]
   },
   {
@@ -118,7 +114,7 @@
    "source": [
     "## Curl\n",
     "\n",
-    "The application deployment is called `image-size`.\n",
+    "The application deployment is called `render-text`.\n",
     "\n",
     "The local DIAL Core server URL is `dial_url`.\n",
     "\n",
@@ -127,7 +123,7 @@
     "Hence the application is accessible via the url:\n",
     "\n",
     "```\n",
-    "http://${DIAL_URL}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\n",
+    "http://${DIAL_URL}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\n",
     "```"
    ]
   },
@@ -140,37 +136,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEsCAIAAABi1XKVAAAEAUlEQVR4nO3WsQ2EQBAEwb8X+ae8JICBt7RUFcFYrTkzP4CE//YAgLcEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsICMa3sAH3LObE94NnO2J/AJHhaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAxpnZngDwjocFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQMYNLe4JVeAYhRsAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<IPython.core.display.Image object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"Size: 400x300px\"}}],\"usage\":null,\"id\":\"410cc421-fe92-4d53-a12d-55dc9a6b67ec\",\"created\":1706099578,\"object\":\"chat.completion\"}"
+      "{\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"custom_content\":{\"attachments\":[{\"index\":0,\"type\":\"image/png\",\"title\":\"Image\",\"data\":\"iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=\"}]},\"content\":\"Image was generated successfully\"}}],\"usage\":null,\"id\":\"9c8169a3-cefe-4e59-a00e-589c7015fc22\",\"created\":1706097619,\"object\":\"chat.completion\"}"
      ]
     }
    ],
    "source": [
-    "image_base64 = read_image_base64(\"./data/images/square.png\")\n",
-    "os.environ[\"IMAGE_BASE64\"] = image_base64\n",
-    "\n",
-    "display_base64_image(image_base64)\n",
-    "\n",
-    "!curl -X POST \"${DIAL_URL}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\" \\\n",
+    "!curl -X POST \"${DIAL_URL}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\" \\\n",
     "  -H \"Api-Key:dial_api_key\" \\\n",
     "  -H \"Content-Type:application/json\" \\\n",
-    "  -d '{ \"messages\": [ { \"role\": \"user\", \"content\": \"\", \"custom_content\": { \"attachments\": [ { \"type\": \"image/png\", \"data\": \"'\"${IMAGE_BASE64}\"'\" } ] } } ] }'"
+    "  -d '{\"messages\": [{\"role\": \"user\", \"content\": \"Hello world!\"}]}'"
    ]
   },
   {
@@ -201,10 +182,15 @@
       "text/plain": [
        "{'choices': [{'index': 0,\n",
        "   'finish_reason': 'stop',\n",
-       "   'message': {'role': 'assistant', 'content': 'Size: 400x300px'}}],\n",
+       "   'message': {'role': 'assistant',\n",
+       "    'custom_content': {'attachments': [{'index': 0,\n",
+       "       'type': 'image/png',\n",
+       "       'title': 'Image',\n",
+       "       'data': 'iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII='}]},\n",
+       "    'content': 'Image was generated successfully'}}],\n",
        " 'usage': None,\n",
-       " 'id': 'a6e1daab-abc2-455d-8f32-b9cafd7b8c99',\n",
-       " 'created': 1706099669,\n",
+       " 'id': 'a9428fed-4c10-4308-8eae-ef7f528e741c',\n",
+       " 'created': 1706097936,\n",
        " 'object': 'chat.completion'}"
       ]
      },
@@ -215,23 +201,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Completion: 'Size: 400x300px'\n"
+      "Completion: 'Image was generated successfully'\n"
      ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
     "response = requests.post(\n",
-    "    f\"{dial_url}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\",\n",
+    "    f\"{dial_url}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\",\n",
     "    headers={\"Api-Key\": \"dial_api_key\"},\n",
-    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"\", \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}}]},\n",
+    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"Hello world!\"}]},\n",
     ")\n",
     "body = response.json()\n",
     "display(body)\n",
-    "\n",
     "message = body[\"choices\"][0][\"message\"]\n",
     "completion = message[\"content\"]\n",
     "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Size: 400x300px\", \"Unexpected completion\""
+    "assert completion == \"Image was generated successfully\", \"Unexpected completion\"\n",
+    "\n",
+    "image_data = message[\"custom_content\"][\"attachments\"][0][\"data\"]\n",
+    "display_base64_image(image_data)"
    ]
   },
   {
@@ -250,11 +248,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"role\":\"assistant\"}}],\"usage\":null,\"id\":\"bcc15e5e-66a1-4e11-bc80-e912dbad66c9\",\"created\":1706099696,\"object\":\"chat.completion.chunk\"}'\n",
+      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"role\":\"assistant\"}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
       "b''\n",
-      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"content\":\"Size: 400x300px\"}}],\"usage\":null,\"id\":\"bcc15e5e-66a1-4e11-bc80-e912dbad66c9\",\"created\":1706099696,\"object\":\"chat.completion.chunk\"}'\n",
+      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"custom_content\":{\"attachments\":[{\"index\":0,\"type\":\"image/png\",\"title\":\"Image\",\"data\":\"iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=\"}]}}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
       "b''\n",
-      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":null,\"id\":\"bcc15e5e-66a1-4e11-bc80-e912dbad66c9\",\"created\":1706099696,\"object\":\"chat.completion.chunk\"}'\n",
+      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"content\":\"Image was generated successfully\"}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
+      "b''\n",
+      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
       "b''\n",
       "b'data: [DONE]'\n",
       "b''\n"
@@ -263,9 +263,9 @@
    ],
    "source": [
     "response = requests.post(\n",
-    "    f\"{dial_url}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\",\n",
+    "    f\"{dial_url}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\",\n",
     "    headers={\"Api-Key\": \"dial_api_key\"},\n",
-    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"\", \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}}], \"stream\": True},\n",
+    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"Hello world!\"}], \"stream\": True},\n",
     ")\n",
     "for chunk in response.iter_lines():\n",
     "    print(chunk)"
@@ -282,13 +282,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "openai_client = openai.AzureOpenAI(\n",
     "    azure_endpoint=dial_url,\n",
-    "    azure_deployment=\"image-size\",\n",
+    "    azure_deployment=\"render-text\",\n",
     "    api_key=\"dial_api_key\",\n",
     "    api_version=\"2023-03-15-preview\",\n",
     ")"
@@ -303,16 +303,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ChatCompletion(id='7b0af319-75b3-4c37-bc84-69d5574ac27a', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Size: 400x300px', role='assistant', function_call=None, tool_calls=None))], created=1706099744, model=None, object='chat.completion', system_fingerprint=None, usage=None)\n",
-      "Completion: 'Size: 400x300px'\n"
+      "ChatCompletion(id='3969e827-f3c5-410f-b3d1-74218ed56310', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Image was generated successfully', role='assistant', function_call=None, tool_calls=None, custom_content={'attachments': [{'index': 0, 'type': 'image/png', 'title': 'Image', 'data': 'iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII='}]}))], created=1706098042, model=None, object='chat.completion', system_fingerprint=None, usage=None)\n",
+      "Completion: 'Image was generated successfully'\n"
      ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -321,17 +331,19 @@
     "    messages=[\n",
     "        {\n",
     "            \"role\": \"user\",\n",
-    "            \"content\": \"\",\n",
-    "            \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}\n",
+    "            \"content\": \"Hello world!\",\n",
     "        }\n",
     "    ],\n",
-    "    model=\"image-size\",\n",
+    "    model=\"render-text\",\n",
     ")\n",
     "print(chat_completion)\n",
     "message = chat_completion.choices[0].message\n",
     "completion = message.content\n",
     "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Size: 400x300px\", \"Unexpected completion\""
+    "assert completion == \"Image was generated successfully\", \"Unexpected completion\"\n",
+    "\n",
+    "image_data = message.custom_content[\"attachments\"][0][\"data\"]\n",
+    "display_base64_image(image_data)"
    ]
   },
   {
@@ -343,17 +355,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ChatCompletionChunk(id='f847cc25-2a53-405c-a0fa-7b98cbb4a44c', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role='assistant', tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706099775, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
-      "ChatCompletionChunk(id='f847cc25-2a53-405c-a0fa-7b98cbb4a44c', choices=[Choice(delta=ChoiceDelta(content='Size: 400x300px', function_call=None, role=None, tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706099775, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
-      "ChatCompletionChunk(id='f847cc25-2a53-405c-a0fa-7b98cbb4a44c', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role=None, tool_calls=None), finish_reason='stop', index=0, logprobs=None)], created=1706099775, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
-      "Completion: 'Size: 400x300px'\n"
+      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role='assistant', tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
+      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role=None, tool_calls=None, custom_content={'attachments': [{'index': 0, 'type': 'image/png', 'title': 'Image', 'data': 'iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII='}]}), finish_reason=None, index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
+      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content='Image was generated successfully', function_call=None, role=None, tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
+      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role=None, tool_calls=None), finish_reason='stop', index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
+      "Completion: 'Image was generated successfully'\n"
      ]
     }
    ],
@@ -362,12 +375,11 @@
     "    messages=[\n",
     "        {\n",
     "            \"role\": \"user\",\n",
-    "            \"content\": \"\",\n",
-    "            \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}\n",
+    "            \"content\": \"Hello world!\",\n",
     "        }\n",
     "    ],\n",
     "    stream=True,\n",
-    "    model=\"image-size\",\n",
+    "    model=\"render-text\",\n",
     ")\n",
     "completion = \"\"\n",
     "for chunk in chat_completion:\n",
@@ -376,7 +388,7 @@
     "    if content:\n",
     "        completion += content\n",
     "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Size: 400x300px\", \"Unexpected completion\""
+    "assert completion == \"Image was generated successfully\", \"Unexpected completion\""
    ]
   },
   {
@@ -390,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +410,7 @@
     "\n",
     "llm = langchain_openai.AzureChatOpenAI(\n",
     "    azure_endpoint=dial_url,\n",
-    "    azure_deployment=\"image-size\",\n",
+    "    azure_deployment=\"render-text\",\n",
     "    api_key=\"dial_api_key\",\n",
     "    api_version=\"2023-03-15-preview\",\n",
     ")"
@@ -413,18 +425,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generations=[[ChatGeneration(text='Image was generated successfully', generation_info={'finish_reason': 'stop', 'logprobs': None}, message=AIMessage(content='Image was generated successfully'))]] llm_output={'token_usage': {}, 'model_name': 'gpt-3.5-turbo'} run=[RunInfo(run_id=UUID('9de1c192-fedc-4a7d-b38d-cd7b4aa221cf'))]\n",
+      "Completion: 'Image was generated successfully'\n"
+     ]
+    }
+   ],
    "source": [
-    "extra_fields = {\"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}}\n",
-    "\n",
-    "try:\n",
-    "  llm.generate(messages=[[HumanMessage(content=\"\", additional_kwargs=extra_fields)]])\n",
-    "\n",
-    "  raise Exception(\"Generation didn't fail\")\n",
-    "except Exception as e:\n",
-    "  assert str(e) == \"Error code: 422 - {'error': {'message': 'No image attachment was found in the last message', 'type': 'runtime_error', 'param': None, 'code': None}}\", \"Unexpected error\""
+    "output = llm.generate(messages=[[HumanMessage(content=\"Hello world!\")]])\n",
+    "print(output)\n",
+    "completion = output.generations[0][0].text\n",
+    "print(f\"Completion: {completion!r}\")\n",
+    "assert completion == \"Image was generated successfully\", \"Unexpected completion\""
    ]
   },
   {
@@ -436,19 +454,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'content': '', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
+      "{'content': '', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
+      "{'content': 'Image was generated successfully', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
+      "{'content': '', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
+      "Completion: 'Image was generated successfully'\n"
+     ]
+    }
+   ],
    "source": [
-    "\n",
-    "try:\n",
-    "    output = llm.stream(input=[HumanMessage(content=\"Hello world!\", additional_kwargs=extra_fields)])\n",
-    "    for chunk in output:\n",
-    "        print(chunk.dict())\n",
-    "\n",
-    "    raise Exception(\"Generation didn't fail\")\n",
-    "except Exception as e:\n",
-    "    assert str(e) == \"Error code: 422 - {'error': {'message': 'No image attachment was found in the last message', 'type': 'runtime_error', 'param': None, 'code': None}}\", \"Unexpected error\"\n"
+    "output = llm.stream(input=[HumanMessage(content=\"Hello world!\")])\n",
+    "completion = \"\"\n",
+    "for chunk in output:\n",
+    "    print(chunk.dict())\n",
+    "    completion += chunk.content\n",
+    "print(f\"Completion: {completion!r}\")\n",
+    "assert completion == \"Image was generated successfully\", \"Unexpected completion\""
    ]
   }
  ],

--- a/dial-cookbook/examples/how_to_call_text_to_image_applications.ipynb
+++ b/dial-cookbook/examples/how_to_call_text_to_image_applications.ipynb
@@ -4,22 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# How to call image-to-text DIAL applications\n",
+    "# How to call text-to-image DIAL applications\n",
     "\n",
-    "This notebook covers how to call image-to-text applications via [DIAL API chat/completions](https://epam-rail.com/dial_api#/paths/~1openai~1deployments~1%7BDeployment%20Name%7D~1chat~1completions/post) call.\n",
+    "This notebook covers how to call text-to-image applications via [DIAL API chat/completions](https://epam-rail.com/dial_api#/paths/~1openai~1deployments~1%7BDeployment%20Name%7D~1chat~1completions/post) call.\n",
     "\n",
     "**DIAL application** is a general term, which encompasses model adapters and application with custom logic.\n",
     "\n",
-    "DIAL currently supports a few image-to-text model adapters:\n",
+    "DIAL currently supports a few text-to-image model adapters:\n",
     "\n",
-    "* [GPT4-Vision](https://github.com/epam/ai-dial-adapter-openai/)\n",
-    "* [Gemini Pro Vision](https://github.com/epam/ai-dial-adapter-vertexai/)\n",
+    "* [DALL-E-3](https://github.com/epam/ai-dial-adapter-openai/)\n",
+    "* [Google Imagen](https://github.com/epam/ai-dial-adapter-vertexai/)\n",
+    "* [Stability diffusion](https://github.com/epam/ai-dial-adapter-bedrock/)\n",
     "\n",
-    "These models follow the same pattern of usage - they take the chat history of interactions between user and model, some of the user messages may contain image attachments, which the model takes into account when it generates the response.\n",
+    "These models follow the same pattern of usage - they take a last user message as a prompt for image generation and return the generated image in the response.\n",
     "\n",
-    "The typical use case is to attach an image to a message and ask the model to describe it in the same message.\n",
-    "\n",
-    "As a simple proxy for these models we'll use an application which take an image in attachment and returns its width and height dimensions.\n",
+    "As a simple proxy for these models we'll use an application which prints the given user prompt as an image.\n",
     "\n",
     "## Setup\n",
     "\n",
@@ -28,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,12 +57,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Run docker compose in a separate terminal to start the DIAL Core server locally along with the `render-text` application.\n",
+    "Run docker compose in a separate terminal to start the DIAL Core server locally along with the `image-size` application.\n",
     "\n",
-    "The `render-text` is a simple text-to-image application which prints the user prompt as an image. We use it as a stand-in for the more complex text-to-image models.\n",
+    "`image-size` is a simple image-to-text application which returns dimensions of an attached image.\n",
     "\n",
     "```sh\n",
-    "(cd ..; docker compose up core render-text)\n",
+    "(cd ..; docker compose up core image-size)\n",
     "```"
    ]
   },
@@ -76,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,12 +88,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Helpers to display images in the notebook:"
+    "Helpers to read images from disk and display images in the notebook:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +104,12 @@
     "\n",
     "def display_base64_image(image_base64):\n",
     "    image_binary = base64.b64decode(image_base64)\n",
-    "    display(IPImage(data=image_binary))"
+    "    display(IPImage(data=image_binary))\n",
+    "\n",
+    "def read_image_base64(image_path: str) -> str:\n",
+    "    with open(image_path, \"rb\") as image_file:\n",
+    "        image_base64 = base64.b64encode(image_file.read()).decode()\n",
+    "    return image_base64\n"
    ]
   },
   {
@@ -114,7 +118,7 @@
    "source": [
     "## Curl\n",
     "\n",
-    "The application deployment is called `render-text`.\n",
+    "The application deployment is called `image-size`.\n",
     "\n",
     "The local DIAL Core server URL is `dial_url`.\n",
     "\n",
@@ -123,7 +127,7 @@
     "Hence the application is accessible via the url:\n",
     "\n",
     "```\n",
-    "http://${DIAL_URL}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\n",
+    "http://${DIAL_URL}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\n",
     "```"
    ]
   },
@@ -136,22 +140,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEsCAIAAABi1XKVAAAEAUlEQVR4nO3WsQ2EQBAEwb8X+ae8JICBt7RUFcFYrTkzP4CE//YAgLcEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsIAMwQIyBAvIECwgQ7CADMECMgQLyBAsIEOwgAzBAjIEC8gQLCBDsICMa3sAH3LObE94NnO2J/AJHhaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAxpnZngDwjocFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQIZgARmCBWQIFpAhWECGYAEZggVkCBaQIVhAhmABGYIFZAgWkCFYQMYNLe4JVeAYhRsAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"custom_content\":{\"attachments\":[{\"index\":0,\"type\":\"image/png\",\"title\":\"Image\",\"data\":\"iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=\"}]},\"content\":\"Image was generated successfully\"}}],\"usage\":null,\"id\":\"9c8169a3-cefe-4e59-a00e-589c7015fc22\",\"created\":1706097619,\"object\":\"chat.completion\"}"
+      "{\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\"Size: 400x300px\"}}],\"usage\":null,\"id\":\"410cc421-fe92-4d53-a12d-55dc9a6b67ec\",\"created\":1706099578,\"object\":\"chat.completion\"}"
      ]
     }
    ],
    "source": [
-    "!curl -X POST \"${DIAL_URL}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\" \\\n",
+    "image_base64 = read_image_base64(\"./data/images/square.png\")\n",
+    "os.environ[\"IMAGE_BASE64\"] = image_base64\n",
+    "\n",
+    "display_base64_image(image_base64)\n",
+    "\n",
+    "!curl -X POST \"${DIAL_URL}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\" \\\n",
     "  -H \"Api-Key:dial_api_key\" \\\n",
     "  -H \"Content-Type:application/json\" \\\n",
-    "  -d '{\"messages\": [{\"role\": \"user\", \"content\": \"Hello world!\"}]}'"
+    "  -d '{ \"messages\": [ { \"role\": \"user\", \"content\": \"\", \"custom_content\": { \"attachments\": [ { \"type\": \"image/png\", \"data\": \"'\"${IMAGE_BASE64}\"'\" } ] } } ] }'"
    ]
   },
   {
@@ -182,15 +201,10 @@
       "text/plain": [
        "{'choices': [{'index': 0,\n",
        "   'finish_reason': 'stop',\n",
-       "   'message': {'role': 'assistant',\n",
-       "    'custom_content': {'attachments': [{'index': 0,\n",
-       "       'type': 'image/png',\n",
-       "       'title': 'Image',\n",
-       "       'data': 'iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII='}]},\n",
-       "    'content': 'Image was generated successfully'}}],\n",
+       "   'message': {'role': 'assistant', 'content': 'Size: 400x300px'}}],\n",
        " 'usage': None,\n",
-       " 'id': 'a9428fed-4c10-4308-8eae-ef7f528e741c',\n",
-       " 'created': 1706097936,\n",
+       " 'id': 'a6e1daab-abc2-455d-8f32-b9cafd7b8c99',\n",
+       " 'created': 1706099669,\n",
        " 'object': 'chat.completion'}"
       ]
      },
@@ -201,35 +215,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Completion: 'Image was generated successfully'\n"
+      "Completion: 'Size: 400x300px'\n"
      ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<IPython.core.display.Image object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
     "response = requests.post(\n",
-    "    f\"{dial_url}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\",\n",
+    "    f\"{dial_url}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\",\n",
     "    headers={\"Api-Key\": \"dial_api_key\"},\n",
-    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"Hello world!\"}]},\n",
+    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"\", \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}}]},\n",
     ")\n",
     "body = response.json()\n",
     "display(body)\n",
+    "\n",
     "message = body[\"choices\"][0][\"message\"]\n",
     "completion = message[\"content\"]\n",
     "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Image was generated successfully\", \"Unexpected completion\"\n",
-    "\n",
-    "image_data = message[\"custom_content\"][\"attachments\"][0][\"data\"]\n",
-    "display_base64_image(image_data)"
+    "assert completion == \"Size: 400x300px\", \"Unexpected completion\""
    ]
   },
   {
@@ -248,13 +250,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"role\":\"assistant\"}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
+      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"role\":\"assistant\"}}],\"usage\":null,\"id\":\"bcc15e5e-66a1-4e11-bc80-e912dbad66c9\",\"created\":1706099696,\"object\":\"chat.completion.chunk\"}'\n",
       "b''\n",
-      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"custom_content\":{\"attachments\":[{\"index\":0,\"type\":\"image/png\",\"title\":\"Image\",\"data\":\"iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=\"}]}}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
+      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"content\":\"Size: 400x300px\"}}],\"usage\":null,\"id\":\"bcc15e5e-66a1-4e11-bc80-e912dbad66c9\",\"created\":1706099696,\"object\":\"chat.completion.chunk\"}'\n",
       "b''\n",
-      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":null,\"delta\":{\"content\":\"Image was generated successfully\"}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
-      "b''\n",
-      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":null,\"id\":\"daf6fbc2-666b-48f2-91d9-1dca46762153\",\"created\":1706097974,\"object\":\"chat.completion.chunk\"}'\n",
+      "b'data: {\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"delta\":{}}],\"usage\":null,\"id\":\"bcc15e5e-66a1-4e11-bc80-e912dbad66c9\",\"created\":1706099696,\"object\":\"chat.completion.chunk\"}'\n",
       "b''\n",
       "b'data: [DONE]'\n",
       "b''\n"
@@ -263,9 +263,9 @@
    ],
    "source": [
     "response = requests.post(\n",
-    "    f\"{dial_url}/openai/deployments/render-text/chat/completions?api-version=2023-03-15-preview\",\n",
+    "    f\"{dial_url}/openai/deployments/image-size/chat/completions?api-version=2023-03-15-preview\",\n",
     "    headers={\"Api-Key\": \"dial_api_key\"},\n",
-    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"Hello world!\"}], \"stream\": True},\n",
+    "    json={\"messages\": [{\"role\": \"user\", \"content\": \"\", \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}}], \"stream\": True},\n",
     ")\n",
     "for chunk in response.iter_lines():\n",
     "    print(chunk)"
@@ -282,13 +282,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
     "openai_client = openai.AzureOpenAI(\n",
     "    azure_endpoint=dial_url,\n",
-    "    azure_deployment=\"render-text\",\n",
+    "    azure_deployment=\"image-size\",\n",
     "    api_key=\"dial_api_key\",\n",
     "    api_version=\"2023-03-15-preview\",\n",
     ")"
@@ -303,26 +303,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ChatCompletion(id='3969e827-f3c5-410f-b3d1-74218ed56310', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Image was generated successfully', role='assistant', function_call=None, tool_calls=None, custom_content={'attachments': [{'index': 0, 'type': 'image/png', 'title': 'Image', 'data': 'iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII='}]}))], created=1706098042, model=None, object='chat.completion', system_fingerprint=None, usage=None)\n",
-      "Completion: 'Image was generated successfully'\n"
+      "ChatCompletion(id='7b0af319-75b3-4c37-bc84-69d5574ac27a', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Size: 400x300px', role='assistant', function_call=None, tool_calls=None))], created=1706099744, model=None, object='chat.completion', system_fingerprint=None, usage=None)\n",
+      "Completion: 'Size: 400x300px'\n"
      ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<IPython.core.display.Image object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -331,19 +321,17 @@
     "    messages=[\n",
     "        {\n",
     "            \"role\": \"user\",\n",
-    "            \"content\": \"Hello world!\",\n",
+    "            \"content\": \"\",\n",
+    "            \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}\n",
     "        }\n",
     "    ],\n",
-    "    model=\"render-text\",\n",
+    "    model=\"image-size\",\n",
     ")\n",
     "print(chat_completion)\n",
     "message = chat_completion.choices[0].message\n",
     "completion = message.content\n",
     "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Image was generated successfully\", \"Unexpected completion\"\n",
-    "\n",
-    "image_data = message.custom_content[\"attachments\"][0][\"data\"]\n",
-    "display_base64_image(image_data)"
+    "assert completion == \"Size: 400x300px\", \"Unexpected completion\""
    ]
   },
   {
@@ -355,18 +343,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role='assistant', tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
-      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role=None, tool_calls=None, custom_content={'attachments': [{'index': 0, 'type': 'image/png', 'title': 'Image', 'data': 'iVBORw0KGgoAAAANSUhEUgAAAMgAAABkCAIAAABM5OhcAAAGHUlEQVR4nO3ZXWhTZxzH8e9psrbaiNham6JFQS2+QDOsbL4N6lYmoiK+i7tQbwrihYoX4o26zgtFtwkrgyobY9NuoAiKgi+1RqlvuImgNxNFC0XxtbMqvrRJdpGDMaenNpX9183+Ppyb8+TJk+ecfGfSzEkkEPnHZfX0BuT9pLDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDExL8dluMwbFinp/9NGW5y2DAcx3wz/xcZhfWWO6u72Zlefmf0USgmFJaYMAlr3z6mTKFfP0Ihpk4lGu3e048eZcYMCgvJzqa4mAULuHjRZ9rYsTgON2+mRn79FcchGOTx49RgbS2OQ01NpusnP/cvXaKsjECAFy/8N7l3r3uN+flUVHD2bPeu8f2XSHR9AEOH+j80dKh3kXXrACZPpqaGb75h9GgCAQ4d8l+q48pffQUwciRbt7JnD19+SThMIMAvv3hfev16gJ07UyNVVQSDAAcPpgbnzwdoasp0fSAcprSUadOoqSEW89nkmjXuNdbW8t13TJpEOMzAgWm3ouOd6VVHZpMyDuvYMYCZM2lvd0daWykuZvBg2tp8lvKcnjqF4xCJ8ORJavD2bcJhcnO5cSPtpc+fB1i0KDVSWsoXX5CdzerV7kg8TkEBH37YjfWTVq7sdJOHDwNUVqauMRZj7lzvf6gKK4NJUFJCS4vPUVKSdvtmzQK4ejXt6Rs2ANTX+7xJntM5cwCOHPFu4PvvAdauTRuMxykuprCQeJxEgtu3Aerq+OQTIhF3zu+/A2zc2I31k+7d63STyWu8cCFthRs3FFbakdmkrryeWVhI//7e+HbvBvj2W583yXM6aBBZWbx86d3AtWsAH3/sHa+qArh8mUSCujqAO3fYsAHH4cEDEgm2bAH4449urA8UFHgv/81NFhURDKb+uXp9hEIKK3UEu64GgKIifvvNZ3zxYu7eTZ22tNDezoABPjOfPev6VR49cr9TewwZ4j7qMXs2O3dSX08kQjTK6NGEw3z6KdXVRKPMm0d9PSUljBvXvfWTiXTm4UMGDiQQ8I7n5/P0adfX2EtkGlZuLhUV/uNvCoWIxzlwwGfm8OFdv0p+Pvfv8+qV971vbnYf9fjsM0IhTpxg7VqiUSorASZMoE8fTp5k5kzOnGH58ndf31ffvjx4QCzmbeuvvzJ6ei/xD//cUFZGayvl5VRUpI5YjGiUtraunz5pEvE4DQ3e8ePHASZP9o7n5DBtGqdP09TEtWtMneoOTpxIQwONjTx/zuzZ776+r0iE9nb3T4fX/vyT1ta0kVu33I/RXiqTz0sy/quwthagujo18uQJo0YRCvHsmc9SntPkL16RCE+fpgbv3CEcJieH69d9NvDzzwArVuA43L/vDm7eDLBsGf36pX2jymT9jhfrGdm1C2D6dPePhkSCtjb3R403b8XXX1Nezv79Pf91p0eOzCZlHFZ7O59/DrBkCT/8wI4djBlDVhZ79rgTcnMJBtm1i5YWn9NEgo0bAUaOZNs26uqornZ/Z/rpJ/8NPHxIIMAHH1BWlho8cwYgEGDhQu/8LtfveLGeTcZi7jVWVvLjj+zYwUcfMX48gwen3Yq8PIDy8p5/j3vkyGxSd34gffWKLVsYM4acHMJhZs2isTH16Lp15OWRm8uVKz6nyePwYaZPp6CAYJCiIubN49y5t20v+eVv1aq0PSS/gO/e7TP/7et3vNiOm3z+nE2bGDGC7GyGDGHpUpqbvbeiqoq8PLZv7/n3uEcOJ9GbvweIGf1PaDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMaGwxITCEhMKS0woLDGhsMSEwhITCktMKCwxobDEhMISEwpLTCgsMfE3CAFF1FZJkwQAAAAASUVORK5CYII='}]}), finish_reason=None, index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
-      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content='Image was generated successfully', function_call=None, role=None, tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
-      "ChatCompletionChunk(id='80cd32cd-f36a-41f3-9af4-54947a5243cb', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role=None, tool_calls=None), finish_reason='stop', index=0, logprobs=None)], created=1706098062, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
-      "Completion: 'Image was generated successfully'\n"
+      "ChatCompletionChunk(id='f847cc25-2a53-405c-a0fa-7b98cbb4a44c', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role='assistant', tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706099775, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
+      "ChatCompletionChunk(id='f847cc25-2a53-405c-a0fa-7b98cbb4a44c', choices=[Choice(delta=ChoiceDelta(content='Size: 400x300px', function_call=None, role=None, tool_calls=None), finish_reason=None, index=0, logprobs=None)], created=1706099775, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
+      "ChatCompletionChunk(id='f847cc25-2a53-405c-a0fa-7b98cbb4a44c', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, role=None, tool_calls=None), finish_reason='stop', index=0, logprobs=None)], created=1706099775, model=None, object='chat.completion.chunk', system_fingerprint=None, usage=None)\n",
+      "Completion: 'Size: 400x300px'\n"
      ]
     }
    ],
@@ -375,11 +362,12 @@
     "    messages=[\n",
     "        {\n",
     "            \"role\": \"user\",\n",
-    "            \"content\": \"Hello world!\",\n",
+    "            \"content\": \"\",\n",
+    "            \"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}\n",
     "        }\n",
     "    ],\n",
     "    stream=True,\n",
-    "    model=\"render-text\",\n",
+    "    model=\"image-size\",\n",
     ")\n",
     "completion = \"\"\n",
     "for chunk in chat_completion:\n",
@@ -388,7 +376,7 @@
     "    if content:\n",
     "        completion += content\n",
     "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Image was generated successfully\", \"Unexpected completion\""
+    "assert completion == \"Size: 400x300px\", \"Unexpected completion\""
    ]
   },
   {
@@ -402,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +398,7 @@
     "\n",
     "llm = langchain_openai.AzureChatOpenAI(\n",
     "    azure_endpoint=dial_url,\n",
-    "    azure_deployment=\"render-text\",\n",
+    "    azure_deployment=\"image-size\",\n",
     "    api_key=\"dial_api_key\",\n",
     "    api_version=\"2023-03-15-preview\",\n",
     ")"
@@ -425,24 +413,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "generations=[[ChatGeneration(text='Image was generated successfully', generation_info={'finish_reason': 'stop', 'logprobs': None}, message=AIMessage(content='Image was generated successfully'))]] llm_output={'token_usage': {}, 'model_name': 'gpt-3.5-turbo'} run=[RunInfo(run_id=UUID('9de1c192-fedc-4a7d-b38d-cd7b4aa221cf'))]\n",
-      "Completion: 'Image was generated successfully'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "output = llm.generate(messages=[[HumanMessage(content=\"Hello world!\")]])\n",
-    "print(output)\n",
-    "completion = output.generations[0][0].text\n",
-    "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Image was generated successfully\", \"Unexpected completion\""
+    "extra_fields = {\"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"data\": image_base64}]}}\n",
+    "\n",
+    "try:\n",
+    "  llm.generate(messages=[[HumanMessage(content=\"\", additional_kwargs=extra_fields)]])\n",
+    "\n",
+    "  raise Exception(\"Generation didn't fail\")\n",
+    "except Exception as e:\n",
+    "  assert str(e) == \"Error code: 422 - {'error': {'message': 'No image attachment was found in the last message', 'type': 'runtime_error', 'param': None, 'code': None}}\", \"Unexpected error\""
    ]
   },
   {
@@ -454,29 +436,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'content': '', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
-      "{'content': '', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
-      "{'content': 'Image was generated successfully', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
-      "{'content': '', 'additional_kwargs': {}, 'type': 'AIMessageChunk', 'example': False}\n",
-      "Completion: 'Image was generated successfully'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "output = llm.stream(input=[HumanMessage(content=\"Hello world!\")])\n",
-    "completion = \"\"\n",
-    "for chunk in output:\n",
-    "    print(chunk.dict())\n",
-    "    completion += chunk.content\n",
-    "print(f\"Completion: {completion!r}\")\n",
-    "assert completion == \"Image was generated successfully\", \"Unexpected completion\""
+    "\n",
+    "try:\n",
+    "    output = llm.stream(input=[HumanMessage(content=\"Hello world!\", additional_kwargs=extra_fields)])\n",
+    "    for chunk in output:\n",
+    "        print(chunk.dict())\n",
+    "\n",
+    "    raise Exception(\"Generation didn't fail\")\n",
+    "except Exception as e:\n",
+    "    assert str(e) == \"Error code: 422 - {'error': {'message': 'No image attachment was found in the last message', 'type': 'runtime_error', 'param': None, 'code': None}}\", \"Unexpected error\"\n"
    ]
   }
  ],

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Follow this tutorial to launch AI DIAL Chat with Echo application. As a result, you will be able to access Chat on http://localhost:3000/ and use Echo application to mirror your prompts. 
+Follow this tutorial to launch AI DIAL Chat with Echo application. As a result, you will be able to access Chat on http://localhost:3000/ and use Echo application to mirror your prompts.
 
 ## Prerequisites
 
@@ -8,7 +8,7 @@ Follow this tutorial to launch AI DIAL Chat with Echo application. As a result, 
 
 ## Step 1: Get AI DIAL
 
-[Download](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/application/) AI DIAL.
+[Download](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/application/) AI DIAL.
 
 ## Step 2: Launch Chat
 

--- a/docs/tutorials/quick-start-model.md
+++ b/docs/tutorials/quick-start-model.md
@@ -14,11 +14,11 @@ In this tutorial, you will learn how to quickly launch AI DIAL Chat with a custo
 
 ## Step 1: Get AI DIAL
 
-[Download](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/model/) AI DIAL.
+[Download](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/model/) AI DIAL.
 
 ## Step 2: Configuration
 
-In the **dial-docker-compose/model/core** folder, you can find a [config.json](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/model/core/config.json) configuration file. 
+In the **dial-docker-compose/model/core** folder, you can find a [config.json](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/model/core/config.json) configuration file.
 
 In `config.json`, you can add your Azure model credentials to the chat configuration:
 

--- a/docs/tutorials/quick-start-with-addon.md
+++ b/docs/tutorials/quick-start-with-addon.md
@@ -8,24 +8,24 @@ In this tutorial, you will learn how to launch AI DIAL Chat with a To-Do List Ad
 
 Within the AI DIAL framework, an **Addon** is a service - or any component adhering to its own or provided OpenAPI specification - that empowers LLMs to access and utilize any desired data source or technology to produce their responses.
 
-For example, one might want LLM to access specific data or technology to use for generating its answers. It can be a corporate database, collection of PDF documents, calculation engines, or any other data source or technology. 
+For example, one might want LLM to access specific data or technology to use for generating its answers. It can be a corporate database, collection of PDF documents, calculation engines, or any other data source or technology.
 
 > Refer to [AI DIAL website](https://epam-rail.com/extension-framework) to view typical examples of addons.
 
 ## About AI DIAL Assistants
 
 An Addon can be used in conjunction with a System Prompt to attain a particular behavior for the LLM, allowing for more flexibility and customization in the LLM's responses. Within the AI DIAL framework, we refer to such combinations of Addons and System Prompts as **Assistants**.
-Assistants provide enhanced control over the behavior of LLMs, leading to more tailored and accurate responses that meet specific requirements. 
+Assistants provide enhanced control over the behavior of LLMs, leading to more tailored and accurate responses that meet specific requirements.
 
 Flexibility offered by this combination allows developers to create custom Assistants within the AI DIAL framework. These Assistants can range from simple implementations, like instructing the LLM to provide answers using a specific tone or style (e.g., like a pirate), to more complex use cases, such as limiting the LLM's data scope to a particular geographical location (e.g., providing weather forecasts for Chicago only). Overall, combining Addons and System Prompts allows for better customization and adaptability to diverse situations, resulting in more versatile AI responses.
 
-> Refer to [AI DIAL Assistant](https://github.com/epam/ai-dial-assistant) repository for more information. 
+> Refer to [AI DIAL Assistant](https://github.com/epam/ai-dial-assistant) repository for more information.
 
 ## About To-Do List Addon
 
 In this tutorial, for example purposes, we will show how to quickly launch AI DIAL Chat with the [To-Do List Addon](https://github.com/openai/plugins-quickstart/) by OpenAI. With this addon, one can generate a list of tasks, append new entries, and fetch information about the entries saved in the list.
 
-Following this pattern, you can develop your own addons or use a third-party ones. The only requirement is that it should be compatible with the OpenAPI specification. 
+Following this pattern, you can develop your own addons or use a third-party ones. The only requirement is that it should be compatible with the OpenAPI specification.
 
 ## Prerequisites
 
@@ -35,26 +35,26 @@ Following this pattern, you can develop your own addons or use a third-party one
 2. Account in MS Azure OpenAI Studio.
     > Refer to [Create and Deploy OpenAI Model in Azure](/Deployment/OpenAI%20Model%20Deployment.md) to learn how to create and deploy an OpenAI model in MS Azure.
 
-3. Addon. In this example, it is [To-Do List](https://github.com/openai/plugins-quickstart/) by OpenAI. 
+3. Addon. In this example, it is [To-Do List](https://github.com/openai/plugins-quickstart/) by OpenAI.
 
 ## Step 1: Get AI DIAL
 
-[Download](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/) AI DIAL.
+[Download](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/) AI DIAL.
 
 ## Step 2: Configuration
 
-In **docker-compose.yaml**, you can find sections for [OpenAI Adapter](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/docker-compose.yml#L18) to work with an Azure model, [AI DIAL Assistant](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/docker-compose.yml#L22), [Addon](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/docker-compose.yml#L27), and [AI DIAL Core](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/docker-compose.yml#L29).
+In **docker-compose.yaml**, you can find sections for [OpenAI Adapter](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/docker-compose.yml#L18) to work with an Azure model, [AI DIAL Assistant](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/docker-compose.yml#L22), [Addon](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/docker-compose.yml#L27), and [AI DIAL Core](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/docker-compose.yml#L29).
 
 > * Refer to [AI DIAL Adapter for OpenAI](https://github.com/epam/ai-dial-adapter-openai) to learn more.
 > * Refer to the [AI DIAL Core](https://github.com/epam/ai-dial-core) to view a complete documentation.
 
-In the **/addon** folder, you can find a [Dockerfile](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/addon/Dockerfile) we need to get and launch the To-Do List Addon. 
+In the **/addon** folder, you can find a [Dockerfile](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/addon/Dockerfile) we need to get and launch the To-Do List Addon.
 
-In the **/core** folder, you can find a [config.json](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/core/config.json) configuration file. In this file, you can configure your model, assistant and addon.
+In the **/core** folder, you can find a [config.json](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/core/config.json) configuration file. In this file, you can configure your model, assistant and addon.
 
 ### Configure Model
 
-Add you model credentials in the [config.json](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/core/config.json#L24) file in `upstreams`.
+Add you model credentials in the [config.json](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/core/config.json#L24) file in `upstreams`.
 
 * Supply your **Azure API Keys** for your deployments for the `key` parameter.
 * Replace `https://AZURE_DEPLOYMENT_URL` with your GPT **endpoint** for the `endpoint` parameter. **Note**: in the endpoint, replace `gpt-4` with your Azure deployment name, in case it is different.
@@ -72,7 +72,7 @@ Add you model credentials in the [config.json](https://github.com/epam/ai-dial/t
 
 ### Configure Assistant
 
-Provide the endpoint for AI DIAL Assistant in the [config file](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/core/config.json#L18) in the `assistant` section. 
+Provide the endpoint for AI DIAL Assistant in the [config file](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/core/config.json#L18) in the `assistant` section.
 
 ```json
 "assistant": {
@@ -80,13 +80,13 @@ Provide the endpoint for AI DIAL Assistant in the [config file](https://github.c
   }
 ```
 
-> * Refer to [AI DIAL Assistant](https://github.com/epam/ai-dial-assistant) repository for more information about AI DIAL Assistant. 
+> * Refer to [AI DIAL Assistant](https://github.com/epam/ai-dial-assistant) repository for more information about AI DIAL Assistant.
 
 ### Configure Addon
 
 > In this example, we get information about the name, description etc. from the [addon repository](https://github.com/openai/plugins-quickstart/blob/main/.well-known/ai-plugin.json).
 
-Provide configuration for your addon in the [config file](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/core/config.json#L11) in the `addons` section: 
+Provide configuration for your addon in the [config file](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/core/config.json#L11) in the `addons` section:
 
 ```json
   "addons": {
@@ -98,7 +98,7 @@ Provide configuration for your addon in the [config file](https://github.com/epa
   }
 ```
 
-Configure roles for your addon in the [config file](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/addon/core/config.json#L49) in the `roles` section: 
+Configure roles for your addon in the [config file](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/addon/core/config.json#L49) in the `roles` section:
 
 ```json
 "roles": {
@@ -115,7 +115,7 @@ Configure roles for your addon in the [config file](https://github.com/epam/ai-d
 1. Run the `docker compose up` command from the folder with the `docker-compose` file (**dial-docker-compose/addon**).
 2. Open http://localhost:3000/ in your browser to launch the AI DIAL Chat application.
 
-The AI DIAL Chat is launched with the Azure model we have configured, and the Addon is enabled with the display name you configured for the `addons.displayName` parameter in `config.json`. 
+The AI DIAL Chat is launched with the Azure model we have configured, and the Addon is enabled with the display name you configured for the `addons.displayName` parameter in `config.json`.
 
 ![](img/addon.png)
 

--- a/docs/tutorials/quick-start-with-application.md
+++ b/docs/tutorials/quick-start-with-application.md
@@ -12,7 +12,7 @@ AI DIAL presents a robust Extension Framework and plug-in infrastructure, enabli
 
 > Refer to the [AI DIAL website](https://epam-rail.com/extension-framework) to learn more.
 
-## About AI DIAL Applications 
+## About AI DIAL Applications
 
 In the AI DIAL framework, **Applications** refer to predefined configurations of Addons and other services, or any other custom logic packaged as a ready-to-use solution.
 
@@ -30,7 +30,7 @@ Examples of Applications: guided conversations, hierarchical search.
 
 ## Step 1: Get AI DIAL
 
-[Download](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/application/) AI DIAL.
+[Download](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/application/) AI DIAL.
 
 ## Step 2: Create Echo Application
 
@@ -38,11 +38,11 @@ Create a python file in your project folder and name it `app.py`.
 
 > Refer to the [application file](https://github.com/epam/ai-dial/blob/main/docs/dial-docker-compose/application/echo/app.py).
 
-We use a [dockerfile](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/application/echo) to launch the Echo application.
+We use a [dockerfile](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/application/echo) to launch the Echo application.
 
 ## Step 3: Configuration
 
-1. Your AI DIAL installation has a `core/config.json` file. Open it and add the following lines in the [applications](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/application/core/config.json#L11) section:
+1. Your AI DIAL installation has a `core/config.json` file. Open it and add the following lines in the [applications](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/application/core/config.json#L11) section:
 
     ```json
     "echo": {
@@ -53,7 +53,7 @@ We use a [dockerfile](https://github.com/epam/ai-dial/tree/main/docs/dial-docker
     }
     ```
 
-2. Add your Echo app to the roles you want it to be exposed to. For example, to add it to the `default` role, add the following lines in the [roles](https://github.com/epam/ai-dial/tree/main/docs/dial-docker-compose/application/core/config.json#L47) section:
+2. Add your Echo app to the roles you want it to be exposed to. For example, to add it to the `default` role, add the following lines in the [roles](https://github.com/epam/ai-dial/tree/main/dial-docker-compose/application/core/config.json#L47) section:
 
     ```json
     "default": {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ const config = {
   projectName: "ai-dial", // Usually your repo name.
   deploymentBranch: "gh-pages",
 
-  onBrokenLinks: "throw", //'throw', for exeptions
+  onBrokenLinks: "throw", //'throw', for exceptions
   onBrokenMarkdownLinks: "warn",
 
   // Even if you don't use internationalization, you can use this field to set

--- a/sidebars.js
+++ b/sidebars.js
@@ -59,9 +59,9 @@ const sidebars = {
       type: 'category',
       label: 'Cookbook',
       items: [
-        "Cookbook/dial-cookbook/examples/how_to_call_image_to_text_applications",
+        "Cookbook/dial-cookbook/examples/how_to_call_text_to_text_applications",
         "Cookbook/dial-cookbook/examples/how_to_call_text_to_image_applications",
-        "Cookbook/dial-cookbook/examples/how_to_call_text_to_text_applications"
+        "Cookbook/dial-cookbook/examples/how_to_call_image_to_text_applications",
       ],
     }
   ],


### PR DESCRIPTION
1. Fixed broken links after a folder moved from `docs/dial-docker-compose` to top-level `dial-docker-compose`.
2. Updated submodule for `dial-sdk`
3. Added examples `image_size` and `render_text` from `dial-sdk/examples`
4. Swapped the names of `text-to-image` and `image-to-text` cookbooks, since they were accidentally confused