### PR TITLE
fix: used double quotes for env vars in .env files

### DIFF
--- a/dial-cookbook/.env
+++ b/dial-cookbook/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=../dial-cookbook
+DIAL_DIR="../dial-cookbook"

--- a/dial-cookbook/ci/.env
+++ b/dial-cookbook/ci/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=../dial-cookbook
+DIAL_DIR="../dial-cookbook"

--- a/dial-docker-compose/addon/.env
+++ b/dial-docker-compose/addon/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=./addon
+DIAL_DIR="./addon"

--- a/dial-docker-compose/application/.env
+++ b/dial-docker-compose/application/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=./application
+DIAL_DIR="./application"

--- a/dial-docker-compose/ci/addon/.env
+++ b/dial-docker-compose/ci/addon/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=./addon
+DIAL_DIR="./addon"

--- a/dial-docker-compose/ci/application/.env
+++ b/dial-docker-compose/ci/application/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=./application
+DIAL_DIR="./application"

--- a/dial-docker-compose/ci/model/.env
+++ b/dial-docker-compose/ci/model/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=./model
+DIAL_DIR="./model"

--- a/dial-docker-compose/model/.env
+++ b/dial-docker-compose/model/.env
@@ -1,1 +1,1 @@
-DIAL_DIR=./model
+DIAL_DIR="./model"


### PR DESCRIPTION
A certain DIAL user experienced issues while running the appication quick-start [docker-compose](https://github.com/epam/ai-dial/blob/main/dial-docker-compose/application/docker-compose.yml) in the following environment:

```bash
$ uname -a
Linux dial 6.8.0-31-generic #31-Ubuntu SMP PREEMPT_DYNAMIC Sat Apr 20 00:40:06 UTC 2024 x86_64 x86_64 x86_64
$ cat /etc/os-release | grep NAME
PRETTY_NAME="Ubuntu 24.04 LTS"
NAME="Ubuntu"
$ echo $BASH_VERSION
5.2.21(1)-release
$ cat /etc/passwd | grep dial
dial:x:1000:1000:dial:/home/dial:/bin/bash
```

The following sequence of commands:

```sh
git clone https://github.com/epam/ai-dial.git
cd ai-dial/dial-docker-compose/application
docker compose up
```

led to DIAL Core failing with error complaining about missing Core config file.

It turned out that `docker compose` didn't pick up `$DIAL_DIR` variable from `.env`. And thus the variable was unset when the [common.yml](https://github.com/epam/ai-dial/blob/main/dial-docker-compose/common.yml#L54) was interpolated. As a result `aidial.config.files` was pointing to a wrong directory which was missing DIAL core [config.json](https://github.com/epam/ai-dial/blob/main/dial-docker-compose/application/core/config.json).

The [env file](https://github.com/epam/ai-dial/blob/main/dial-docker-compose/application/.env) looked like this:

```env
DIAL_DIR=./application
```

After many hours of debugging, it turned out that the following env file with double-quotes actually works:

```env
DIAL_DIR="./application"
```

It's still unclear why the original env var wasn't picked up properly in the given environment.