### PR TITLE
fix: declaring .env file in include directive explicitly

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         with:
           compose-file: "./dial-cookbook/ci/docker-compose.yml"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart model example
         with:
           compose-file: "./dial-docker-compose/ci/model/docker-compose.yml"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart application example
         with:
           compose-file: "./dial-docker-compose/ci/application/docker-compose.yml"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart addon example
         with:
           compose-file: "./dial-docker-compose/ci/addon/docker-compose.yml"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: true
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         with:
-          compose-file: "./dial-cookbook/ci/docker-compose.yml"
+          cwd: "./dial-cookbook/ci"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
 
   run-quickstart:
@@ -26,17 +26,17 @@ jobs:
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart model example
         with:
-          compose-file: "./dial-docker-compose/ci/model/docker-compose.yml"
+          cwd: "./dial-docker-compose/ci/model"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart application example
         with:
-          compose-file: "./dial-docker-compose/ci/application/docker-compose.yml"
+          cwd: "./dial-docker-compose/ci/application"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart addon example
         with:
-          compose-file: "./dial-docker-compose/ci/addon/docker-compose.yml"
+          cwd: "./dial-docker-compose/ci/addon"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: true
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         with:
-          compose-file: "./dial-cookbook/ci/docker-compose.yml"
+          cwd: "./dial-cookbook/ci"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
 
   run-quickstart:
@@ -26,17 +26,17 @@ jobs:
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart model example
         with:
-          compose-file: "./dial-docker-compose/ci/model/docker-compose.yml"
+          cwd: "./dial-docker-compose/ci/model"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart application example
         with:
-          compose-file: "./dial-docker-compose/ci/application/docker-compose.yml"
+          cwd: "./dial-docker-compose/ci/application"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
       - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart addon example
         with:
-          compose-file: "./dial-docker-compose/ci/addon/docker-compose.yml"
+          cwd: "./dial-docker-compose/ci/addon"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
 
   build-and-deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         with:
           compose-file: "./dial-cookbook/ci/docker-compose.yml"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
@@ -23,17 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart model example
         with:
           compose-file: "./dial-docker-compose/ci/model/docker-compose.yml"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart application example
         with:
           compose-file: "./dial-docker-compose/ci/application/docker-compose.yml"
           up-flags: "--abort-on-container-exit --exit-code-from test --timeout 300"
-      - uses: isbang/compose-action@178aeba5c9dbeed89ffffbb3e6548ec08e9839cf # v1.5.1
+      - uses: isbang/compose-action@802a148945af6399a338c7906c267331b39a71af # v2.0.0
         name: Run quickstart addon example
         with:
           compose-file: "./dial-docker-compose/ci/addon/docker-compose.yml"

--- a/dial-cookbook/ci/docker-compose.yml
+++ b/dial-cookbook/ci/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../docker-compose.yml
+  - path: ../docker-compose.yml
+    env_file: ./.env
 
 services:
   test:

--- a/dial-cookbook/ci/docker-compose.yml
+++ b/dial-cookbook/ci/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../docker-compose.yml
     env_file: ./.env

--- a/dial-cookbook/docker-compose.yml
+++ b/dial-cookbook/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../dial-docker-compose/common.yml
     env_file: ./.env

--- a/dial-cookbook/docker-compose.yml
+++ b/dial-cookbook/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../dial-docker-compose/common.yml
+  - path: ../dial-docker-compose/common.yml
+    env_file: ./.env
 
 services:
   echo:

--- a/dial-docker-compose/addon/docker-compose.yml
+++ b/dial-docker-compose/addon/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../common.yml
     env_file: ./.env

--- a/dial-docker-compose/addon/docker-compose.yml
+++ b/dial-docker-compose/addon/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../common.yml
+  - path: ../common.yml
+    env_file: ./.env
 
 services:
   adapter-openai:

--- a/dial-docker-compose/application/docker-compose.yml
+++ b/dial-docker-compose/application/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../common.yml
+  - path: ../common.yml
+    env_file: ./.env
 
 services:
   echo:

--- a/dial-docker-compose/application/docker-compose.yml
+++ b/dial-docker-compose/application/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../common.yml
     env_file: ./.env

--- a/dial-docker-compose/ci/addon/docker-compose.yml
+++ b/dial-docker-compose/ci/addon/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../../addon/docker-compose.yml
+  - path: ../../addon/docker-compose.yml
+    env_file: ./.env
 
 services:
   azure_deployment_host:

--- a/dial-docker-compose/ci/addon/docker-compose.yml
+++ b/dial-docker-compose/ci/addon/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../../addon/docker-compose.yml
     env_file: ./.env

--- a/dial-docker-compose/ci/application/docker-compose.yml
+++ b/dial-docker-compose/ci/application/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../../application/docker-compose.yml
     env_file: ./.env

--- a/dial-docker-compose/ci/application/docker-compose.yml
+++ b/dial-docker-compose/ci/application/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../../application/docker-compose.yml
+  - path: ../../application/docker-compose.yml
+    env_file: ./.env
 
 services:
   test:

--- a/dial-docker-compose/ci/model/docker-compose.yml
+++ b/dial-docker-compose/ci/model/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../../model/docker-compose.yml
+  - path: ../../model/docker-compose.yml
+    env_file: ./.env
 
 services:
   azure_deployment_host:

--- a/dial-docker-compose/ci/model/docker-compose.yml
+++ b/dial-docker-compose/ci/model/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../../model/docker-compose.yml
     env_file: ./.env

--- a/dial-docker-compose/common.yml
+++ b/dial-docker-compose/common.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 services:
   themes:
     image: epam/ai-dial-chat-themes:0.4.0

--- a/dial-docker-compose/model/docker-compose.yml
+++ b/dial-docker-compose/model/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: '3'
-
 include:
   - path: ../common.yml
     env_file: ./.env

--- a/dial-docker-compose/model/docker-compose.yml
+++ b/dial-docker-compose/model/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 include:
-  - ../common.yml
+  - path: ../common.yml
+    env_file: ./.env
 
 services:
   adapter-openai:


### PR DESCRIPTION
Resolves issue discribed at https://github.com/epam/ai-dial/pull/105.

As per [documentation](https://docs.docker.com/compose/compose-file/14-include/#env_file) env file of an **included** docker-compose file is `./.env` relative  to this **included file**.

However, we want env file to be resolved relative to the **parent** docker-compose file. To achieve this we need to especify env file via `env_file` field.