### PR TITLE
docs: Add RP-Initiated Logout and Allowed Logout URLs configuration to Auth0 setup

### DIFF
--- a/docs/Auth/2. Web/2.IDPs/auth0.md
+++ b/docs/Auth/2. Web/2.IDPs/auth0.md
@@ -36,10 +36,13 @@ Follow these steps to configure Auth0:
 3. **Configure Application Settings:** in the [**Applications/Settings**](https://auth0.com/docs/get-started/applications/application-settings) section, set the following parameters:
     - Obtain and save **Domain**,**Client ID** and **Client secrets** generated for your application.
     - Allowed Callback URLs: `https://<chat_url>/api/auth/callback/auth0`
-4. **Create API:** in the **Applications/APIs** section, configure a new [**API**](https://auth0.com/docs/get-started/apis/api-settings).
-5. **Create Users:** in the **User Management/Users** section, create necessary [Users](https://auth0.com/docs/manage-users/user-accounts/create-users).
-6. (Optional) **Create and Assign Roles:** in the **User Management/Roles** section, create necessary [Roles](https://auth0.com/docs/manage-users/access-control/configure-core-rbac/roles/create-roles).
-7. (Optional) **Create Action:** in the **Actions/Library** section, create a necessary [Action](https://auth0.com/docs/customize/actions/write-your-first-action#create-an-action) and [Deploy](https://auth0.com/docs/customize/actions/write-your-first-action#deploy-the-action) it. Action parameters:
+4. **Update Application Allowed Logout URLs:** in the [**Applications/Settings**](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0#update-application-allowed-logout-urls), add the following:
+    - Allowed Logout URLs: `https://<chat_url>/api/auth/logout`
+5. **Configure RP-Initiated Logout:** follow the [Auth0 documentation](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-auth0#configure-rp-initiated-logout) to configure RP-Initiated Logout in your application.
+6. **Create API:** in the **Applications/APIs** section, configure a new [**API**](https://auth0.com/docs/get-started/apis/api-settings).
+7. **Create Users:** in the **User Management/Users** section, create necessary [Users](https://auth0.com/docs/manage-users/user-accounts/create-users).
+8. (Optional) **Create and Assign Roles:** in the **User Management/Roles** section, create necessary [Roles](https://auth0.com/docs/manage-users/access-control/configure-core-rbac/roles/create-roles).
+9. (Optional) **Create Action:** in the **Actions/Library** section, create a necessary [Action](https://auth0.com/docs/customize/actions/write-your-first-action#create-an-action) and [Deploy](https://auth0.com/docs/customize/actions/write-your-first-action#deploy-the-action) it. Action parameters:
    - Name: `DIAL role`
    - Trigger: `Login/Post Login`
    - Runtime: `Node 18`
@@ -52,7 +55,8 @@ Follow these steps to configure Auth0:
        }
      };
      ```   
-8. (Optional) **Configure the Login Flow:** in the **Actions/Flows** section, choose `Login`, add a custom action `DIAL role` to `Flow` and apply the change. Refer to [Auth0](https://auth0.com/docs/customize/actions/flows-and-triggers) documentation to learn more.
+10. (Optional) **Configure the Login Flow:** in the **Actions/Flows** section, choose `Login`, add a custom action `DIAL role` to `Flow` and apply the change. Refer to [Auth0](https://auth0.com/docs/customize/actions/flows-and-triggers) documentation to learn more.
+
 
 ### Configure AI DIAL
 


### PR DESCRIPTION
This PR updates the documentation for configuring Auth0 as an identity provider in AI DIAL. The following changes have been made:
- Added instructions for configuring **RP-Initiated Logout** following Auth0 guidelines.
- Included steps to update the **Allowed Logout URLs** in the Auth0 application settings.
- Clarified the integration steps between Auth0 and AI DIAL for better user guidance.

These changes ensure a complete logout experience by configuring the necessary settings in Auth0.
