### PR TITLE
fix[cookbooks]: pinned version of httpx==0.27.2

### DIFF
--- a/dial-cookbook/ci/test/Dockerfile
+++ b/dial-cookbook/ci/test/Dockerfile
@@ -12,12 +12,13 @@ RUN apk add --no-cache \
     make \
     zeromq-dev
 
-RUN pip install jupyter
+RUN pip install jupyter==1.1.1
 
 # NOTE: for some reason jupyter doesn't run pip-installs inside the notebooks,
 # so we have to repeat them here.
 RUN pip install requests==2.31.0
 RUN pip install openai==1.9.0
+RUN pip install httpx==0.27.2
 RUN pip install langchain-openai==0.0.3
 
 WORKDIR /app

--- a/dial-cookbook/examples/how_to_call_image_to_text_applications.ipynb
+++ b/dial-cookbook/examples/how_to_call_image_to_text_applications.ipynb
@@ -608,18 +608,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "extra_fields = {\"custom_content\": {\"attachments\": [{\"type\": \"image/png\", \"url\": dial_image_url}]}}\n",
     "\n",
     "try:\n",
-    "  llm.generate(messages=[[HumanMessage(content=\"\", additional_kwargs=extra_fields)]])\n",
+    "    llm.generate(messages=[[HumanMessage(content=\"\", additional_kwargs=extra_fields)]])\n",
     "\n",
-    "  raise Exception(\"Generation didn't fail\")\n",
-    "except openai.UnprocessableEntityError as e:\n",
-    "  assert e.body[\"message\"] == \"No image attachment was found in the last message\""
+    "    raise Exception(\"Generation didn't fail\")\n",
+    "except openai.APIError as e:\n",
+    "    assert e.body[\"message\"] == \"No image attachment was found in the last message\""
    ]
   },
   {
@@ -631,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,8 +641,8 @@
     "        print(chunk.dict())\n",
     "\n",
     "    raise Exception(\"Generation didn't fail\")\n",
-    "except openai.UnprocessableEntityError as e:\n",
-    "  assert e.body[\"message\"] == \"No image attachment was found in the last message\""
+    "except openai.APIError as e:\n",
+    "    assert e.body[\"message\"] == \"No image attachment was found in the last message\""
    ]
   }
  ],

--- a/dial-cookbook/examples/how_to_call_image_to_text_applications.ipynb
+++ b/dial-cookbook/examples/how_to_call_image_to_text_applications.ipynb
@@ -38,6 +38,7 @@
    "source": [
     "!pip install requests==2.32.3\n",
     "!pip install openai==1.43.0\n",
+    "!pip install httpx==0.27.2\n",
     "!pip install langchain-openai==0.1.23"
    ]
   },
@@ -661,7 +662,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/dial-cookbook/examples/how_to_call_text_to_image_applications.ipynb
+++ b/dial-cookbook/examples/how_to_call_text_to_image_applications.ipynb
@@ -45,6 +45,7 @@
    "source": [
     "!pip install requests==2.32.3\n",
     "!pip install openai==1.43.0\n",
+    "!pip install httpx==0.27.2\n",
     "!pip install langchain-openai==0.1.23"
    ]
   },
@@ -837,7 +838,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/dial-cookbook/examples/how_to_call_text_to_text_applications.ipynb
+++ b/dial-cookbook/examples/how_to_call_text_to_text_applications.ipynb
@@ -27,6 +27,7 @@
    "source": [
     "!pip install requests==2.32.3\n",
     "!pip install openai==1.43.0\n",
+    "!pip install httpx==0.27.2\n",
     "!pip install langchain-openai==0.1.23"
    ]
   },
@@ -425,7 +426,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
[httpx==0.28.0](https://github.com/encode/httpx/releases/tag/0.28.0) has introduced the breaking change: `proxies` argument has been removed from HTTPX client constructor.

1. `openai` lib doesn't pin the version of its `httpx` dependency: https://github.com/openai/openai-python/blob/main/pyproject.toml#L11:

```
dependencies = [
    "httpx>=0.23.0, <1",
    "pydantic>=1.9.0, <3",
    "typing-extensions>=4.11, <5",
...
```

2. `openai` lib does use `proxies` argument of the HTTPX client.

This leads to the runtime error:

> TypeError: Client.__init__() got an unexpected keyword argument 'proxies'

To fix this, one needs to limit the version of `httpx` to `<=0.27` or migrate to the [latest](https://github.com/openai/openai-python/releases/tag/v1.55.3) `openai` which was made compatible with `httpx==0.28.0`.