### PR TITLE
chore: increase retries for Ollama self-hosted docker-compose

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,28 +57,8 @@ jobs:
       - name: Docker Compose pull
         shell: bash
         run: |
-          set -euo pipefail
           cd ./dial-docker-compose/ci/ollama
-
-          attempts=5
-          for i in $(seq 1 $attempts); do
-            echo "Pull attempt $i/$attempts"
-            if docker compose pull --quiet; then
-              echo "Pull succeeded"
-              exit 0
-            fi
-
-            rc=$?
-            echo "Pull failed (exit $rc). Diagnostics:"
-            docker --version || true
-            docker compose version || true
-
-            echo "Sleeping before retry..."
-            sleep $((10 * i))
-          done
-
-          echo "All pull attempts failed."
-          exit 1
+          docker compose pull --quiet
       - name: Docker Compose up
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,28 +58,8 @@ jobs:
       - name: Docker Compose pull
         shell: bash
         run: |
-          set -euo pipefail
           cd ./dial-docker-compose/ci/ollama
-
-          attempts=5
-          for i in $(seq 1 $attempts); do
-            echo "Pull attempt $i/$attempts"
-            if docker compose pull --quiet; then
-              echo "Pull succeeded"
-              exit 0
-            fi
-
-            rc=$?
-            echo "Pull failed (exit $rc). Diagnostics:"
-            docker --version || true
-            docker compose version || true
-
-            echo "Sleeping before retry..."
-            sleep $((10 * i))
-          done
-
-          echo "All pull attempts failed."
-          exit 1
+          docker compose pull --quiet
       - name: Docker Compose up
         shell: bash
         run: |

--- a/dial-docker-compose/ollama/ollama_setup/Dockerfile
+++ b/dial-docker-compose/ollama/ollama_setup/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install -r requirements.txt
 
 EXPOSE 5000
 
-HEALTHCHECK --interval=10s --timeout=1s --start-period=10s --retries=10 \
+HEALTHCHECK --interval=10s --timeout=1s --start-period=10s --retries=30 \
   CMD curl --fail http://localhost:5000/health || exit 1
 
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000"]


### PR DESCRIPTION
An attempt to mitigate intermittent CI job failures: https://github.com/epam/ai-dial/actions/runs/21251503810