### PR TITLE
docs: rewrite Quick Apps deployment guide for Quick Apps 2.0

### DIFF
--- a/docs/tutorials/2.devops/0.deployment/3.quick_apps_deployment.md
+++ b/docs/tutorials/2.devops/0.deployment/3.quick_apps_deployment.md
@@ -41,7 +41,7 @@ Follow this guide to deploy the Quick Apps 2.0 service and wire it into your DIA
 ## Step 1: Update Components
 
 Make sure the following components are at compatible versions. The versions below correspond to DIAL
-release `1.44` — check the [latest release notes](/docs/releases/1.44/1.44-release-notes.md) for the current stable line.
+release `1.44` — check the [latest release notes](https://github.com/epam/ai-dial/tree/main/docs/releases) for the current stable line.
 
 | Component | Version |
 |-----------|---------|

--- a/docs/tutorials/2.devops/0.deployment/3.quick_apps_deployment.md
+++ b/docs/tutorials/2.devops/0.deployment/3.quick_apps_deployment.md
@@ -1,1513 +1,185 @@
-# Quick Apps Installation Instructions
+# Quick Apps 2.0 Installation Instructions
 
 ## Introduction
 
-Install the Quick Apps component to be able to use Quick Apps in your deployment of DIAL. Follow this guide to do this.
+**Quick Apps 2.0** is DIAL's open-source, no-code agent composer. It lets users assemble task-oriented
+workflows from DIAL agents (DIAL-native applications and AI models) and external integrations
+(REST APIs, MCP servers), with any tool-calling model registered in DIAL Core acting as the agent
+orchestrator.
 
-##### Prerequisites
+Quick Apps 2.0 has two parts:
 
-Ensure that you have the necessary permissions to deploy and configure Helm charts and services within the Kubernetes cluster.
+* The **runtime** — distributed as a standalone service,
+  [ai-dial-quickapps-backend](https://github.com/epam/ai-dial-quickapps-backend) — which executes the
+  agent workflow and serves the configuration schema. You deploy it and register it in DIAL Core as a
+  custom [application type](/docs/platform/3.core/7.apps.md#application-types).
+* The **no-code configurator** — the editor UI used to create and edit Quick Apps 2.0 instances —
+  which ships as part of **DIAL Chat**. Its capabilities therefore track the DIAL Chat version, not the
+  backend version; keep DIAL Chat current to get the latest editor features.
+
+Follow this guide to deploy the Quick Apps 2.0 service and wire it into your DIAL installation.
+
+> [!NOTE]
+> Quick Apps 2.0 is a [schema-rich application](/docs/platform/3.core/7.apps.md#schema-rich-applications):
+> DIAL Core stores the application-type schema and brokers requests, while the agent logic runs in the
+> Quick Apps 2.0 container. The legacy **Quick Apps** application type is a separate, SaaS-only offering and
+> is not covered here.
+
+> * Concepts: [DIAL-Native Applications](/docs/platform/3.core/7.apps.md) and [Quick Apps 2.0](/docs/platform/3.core/7.apps.md#quick-apps-20).
+> * Full configuration reference: [CONFIGURATION.md](https://github.com/epam/ai-dial-quickapps-backend/blob/development/CONFIGURATION.md).
+> * Application-type registration reference: [application-schema.md](https://github.com/epam/ai-dial-quickapps-backend/blob/development/docs/application-schema.md).
+
+## Prerequisites
+
+* Permissions to deploy and configure Helm charts and services within the Kubernetes cluster.
+* **DIAL Core `0.41.0` or higher** — the minimum version that supports the application-type schema
+  endpoint used below. The `dial:applicationTypeRoutes` block additionally requires Core from the
+  DIAL `1.44` line (`0.44.0`+); see [Step 3](#step-3-register-the-application-type-in-dial-core).
+* At least one tool-calling LLM deployment (model or DIAL application) registered in DIAL Core to act
+  as the orchestrator.
 
 ## Step 1: Update Components
 
-Make sure the following components are updated to the specified versions:
+Make sure the following components are at compatible versions. The versions below correspond to DIAL
+release `1.44` — check the [latest release notes](/docs/releases/1.44/1.44-release-notes.md) for the current stable line.
 
-* [DIAL Core](https://github.com/epam/ai-dial-core) to version 0.28.0 or higher.
-* [DIAL Chat](https://github.com/epam/ai-dial-chat) to version 0.29.0.
+| Component | Version |
+|-----------|---------|
+| [ai-dial-quickapps-backend](https://github.com/epam/ai-dial-quickapps-backend) | `0.8.0` or higher |
+| [DIAL Core](https://github.com/epam/ai-dial-core) | `0.44.0` (`0.41.0` minimum — see [Prerequisites](#prerequisites)) |
+| [DIAL Chat](https://github.com/epam/ai-dial-chat) | `0.46.0` or higher |
 
-## Step 2: Deploy Quick Apps with Helm
+> [!NOTE]
+> The Quick Apps 2.0 configurator ships with DIAL Chat, so the DIAL Chat version determines which editor
+> features are available. Upgrade DIAL Chat to get the latest configurator capabilities.
 
-Run the following Helm command to deploy Quick Apps:
+## Step 2: Deploy Quick Apps 2.0 with Helm
+
+The image is published to the public GitHub Container Registry at
+`ghcr.io/epam/ai-dial-quickapps-backend`. Deploy it with the `dial-extension` Helm chart:
 
 ```bash
-helm upgrade --install dial-quickapps dial/dial-extension -f ./values.yaml -n dial
+helm upgrade --install quickapps2 dial/dial-extension -f ./values.yaml --version <chart-version> -n dial
 ```
 
-##### Example of a values.yaml file
+##### Example `values.yaml`
 
 ```yaml
-# This section is provided as an example. Please use the actual image.
+# This section is an example. Pin the image tag to a released version.
 image:
-  pullPolicy: Always
-  registry: registry.deltixhub.com
-  repository: ai/dial/application/quickapps
-  tag: development
-  pullSecrets:
-    - dial-dev-registry
+  registry: ghcr.io
+  repository: epam/ai-dial-quickapps-backend
+  tag: "0.8.0"
+  pullPolicy: IfNotPresent
 
-podAnnotations:
-  autorestart: '{{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC" }}'
-
-  fullnameOverride: quickapps
+fullnameOverride: quickapps2
 
 ingress:
   enabled: false
 
-serviceAccount:
-  create: true
-
 env:
+  # URL of the DIAL Core API (only required variable).
   DIAL_URL: "http://dial-core.dial.svc.cluster.local"
-  API_VERSION: "2025-01-01-preview"
-  TEMPERATURE_FALLBACK: "true"
-  SYSTEM_PROMPT_FALLBACK: "true"
 
-# API_VERSION sets a unified protocol version used to call models and other apps from quick app executor
-# You can omit API_VERSION than default value "2025-01-01-preview" will be applied
-# TEMPERATURE_FALLBACK - if true, quckapp will not set temperature in the request to the model, if model does not support it
-# SYSTEM_PROMPT_FALLBACK - if true, quckapp will append instructions to every human message, if model does not support system prompt
-# You also can set RAG_DEPLOYMENT_NAME if you want to modify the "default" RAG to be used ("dial-rag" if not set)
-
+  # Default orchestrator model used when an app manifest omits `orchestrator.deployment`.
+  # Must be a tool-calling deployment registered in DIAL Core. Also pre-fills new apps in the editor.
+  DEFAULT_ORCHESTRATOR_DEPLOYMENT_ID: "gpt-5.2-2025-12-11"
 ```
 
-## Step 3: Configure DIAL Core
+> [!NOTE]
+> The service listens on port `5000` and is reachable in-cluster at
+> `http://quickapps2.dial.svc.cluster.local`. `DIAL_URL` is the only required environment variable;
+> see the full [Environment Variables](https://github.com/epam/ai-dial-quickapps-backend/tree/development#environment-variables) reference.
 
-After deploying Quick Apps, configure DIAL Core to use the Quick Apps component. To do this: 
+## Step 3: Register the Application Type in DIAL Core
 
-1. Add the [Quick Apps application type JSON schema](#quick-apps-schema) to the DIAL Core configuration.
-2. Update `"dial:applicationTypeCompletionEndpoint"` and `"dial:applicationTypeConfigurationEndpoint"` with the Quick Apps service endpoints created in [Step 2](#step-2-deploy-quick-apps-with-helm).
+Add the Quick Apps 2.0 application type to the `"applicationTypeSchemas"` array in the DIAL Core
+configuration. With this entry, DIAL Core fetches the configuration schema directly from the running
+service via `dial:applicationTypeSchemaEndpoint`, so you never have to maintain a static schema by hand.
 
-* If `"dial:appendApplicationPropertiesHeader": true`, DIAL Core will append the Quick Apps configuration to the [chat completion request](https://dialx.ai/dial_api#operation/sendChatCompletionRequest) headers. 
-* If `"dial:appendApplicationPropertiesHeader": false`, Quick Apps service will request the configuration from DIAL Core with an additional request. This may be the preferred option if the configuration is very large to append to a request header.
-
-
-## Step 4: DIAL Chat Environment Variables
-
-1. Specify the following environment variables for DIAL Chat:
-
-    ```yaml
-        # The host URL for Quick Apps Completions URLs. Can lead to public and private resources
-        QUICK_APPS_HOST: "http://quickapps.dial.svc.cluster.local" 
-        # applicationTypeSchemaId value for QuickApp application type
-        QUICK_APPS_SCHEMA_ID: "https://mydial.epam.com/custom_application_schemas/quickapps"
-        # A model that will be used in Quick Apps
-        QUICK_APPS_MODEL: "gpt-4o-2024-05-13"
-    ```
-
-2. Add `quick-apps` to `ENABLED_FEATURES`:
-
-    ```yaml
-        ENABLED_FEATURES: "...,quick-apps"
-    ```
-
-## Step 5: DIAL Core Environment Variables
-
-Set the following environment variable for DIAL Core to include custom applications:
-
-```yaml
-    aidial.applications.includeCustomApps: "true"
-```
-
-## Annex
-
-##### Quick Apps Schema
+Replace `<quickapps_base_url>` with the service base URL from [Step 2](#step-2-deploy-quick-apps-20-with-helm)
+(e.g. `http://quickapps2.dial.svc.cluster.local`):
 
 ```json
 {
   "applicationTypeSchemas": [
     {
-      "$schema": "https://dial.epam.com/application_type_schemas/schema#",
-      "$id": "https://mydial.epam.com/custom_application_schemas/quickapps",
-      "dial:applicationTypeDisplayName": "QuickApp",
-      "dial:applicationTypeCompletionEndpoint": "http://quickapps.dial-development.svc.cluster.local/openai/deployments/quick_apps/chat/completions",
-      "dial:applicationTypeConfigurationEndpoint": "http://quickapps.dial-development.svc.cluster.local/openai/deployments/quick_apps/configuration",
-      "dial:appendApplicationPropertiesHeader": true,
-      "$defs": {
-        "ApiKeyAuthorization": {
-          "properties": {
-            "type": {
-              "const": "api_key",
-              "default": "api_key",
-              "title": "Type",
-              "type": "string"
-            },
-            "key": {
-              "title": "Key",
-              "type": "string"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "location": {
-              "$ref": "#/$defs/AuthorizationLocation"
-            }
-          },
-          "required": [
-            "key",
-            "name",
-            "location"
+      "dial:applicationTypeDisplayName": "Quick App 2.0",
+      "dial:appendApplicationPropertiesHeader": false,
+      "dial:applicationTypeAssistantAttachmentsInRequestSupported": true,
+      "dial:applicationTypeCompletionEndpoint": "<quickapps_base_url>/openai/deployments/quick_apps2/chat/completions",
+      "dial:applicationTypeConfigurationEndpoint": "<quickapps_base_url>/openai/deployments/quick_apps2/configuration",
+      "dial:applicationTypeSchemaEndpoint": "<quickapps_base_url>/v1/configuration-support/application-schema",
+      "dial:applicationTypeRoutes": {
+        "configuration_support_read": {
+          "dial:paths": ["/v1/configuration-support(/[^/]+)*$"],
+          "dial:methods": ["GET"],
+          "dial:rewritePath": true,
+          "dial:permissions": ["WRITE"],
+          "dial:upstreams": [
+            {"dial:endpoint": "<quickapps_base_url>"}
+          ]
+        },
+        "configuration_support_skill_validate": {
+          "dial:paths": ["/v1/configuration-support/skills/validate$"],
+          "dial:methods": ["POST"],
+          "dial:rewritePath": true,
+          "dial:permissions": ["WRITE"],
+          "dial:upstreams": [
+            {"dial:endpoint": "<quickapps_base_url>"}
           ],
-          "title": "ApiKeyAuthorization",
-          "type": "object"
-        },
-        "AuthorizationLocation": {
-          "enum": [
-            "header",
-            "query",
-            "body"
-          ],
-          "title": "AuthorizationLocation",
-          "type": "string"
-        },
-        "BasicAuthorization": {
-          "properties": {
-            "type": {
-              "const": "basic",
-              "default": "basic",
-              "title": "Type",
-              "type": "string"
-            },
-            "username": {
-              "title": "Username",
-              "type": "string"
-            },
-            "password": {
-              "title": "Password",
-              "type": "string"
-            }
-          },
-          "required": [
-            "username",
-            "password"
-          ],
-          "title": "BasicAuthorization",
-          "type": "object"
-        },
-        "BearerAuthorization": {
-          "properties": {
-            "type": {
-              "const": "bearer",
-              "default": "bearer",
-              "title": "Type",
-              "type": "string"
-            },
-            "token": {
-              "title": "Token",
-              "type": "string"
-            }
-          },
-          "required": [
-            "token"
-          ],
-          "title": "BearerAuthorization",
-          "type": "object"
-        },
-        "ClientIdSecretAuthorization": {
-          "properties": {
-            "type": {
-              "const": "client_id_secret",
-              "default": "client_id_secret",
-              "title": "Type",
-              "type": "string"
-            },
-            "client_id": {
-              "title": "Client Id",
-              "type": "string"
-            },
-            "client_secret": {
-              "title": "Client Secret",
-              "type": "string"
-            },
-            "token_url": {
-              "title": "Token Url",
-              "type": "string"
-            },
-            "scope": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Scope"
-            },
-            "aud": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Aud"
-            }
-          },
-          "required": [
-            "client_id",
-            "client_secret",
-            "token_url",
-            "scope",
-            "aud"
-          ],
-          "title": "ClientIdSecretAuthorization",
-          "type": "object"
-        },
-        "ClientToolInfo": {
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            },
-            "parameters": {
-              "items": {
-                "$ref": "#/$defs/ClientToolParameterInfo"
-              },
-              "title": "Parameters",
-              "type": "array"
-            }
-          },
-          "required": [
-            "name",
-            "description",
-            "parameters"
-          ],
-          "title": "ClientToolInfo",
-          "type": "object"
-        },
-        "ClientToolParameterInfo": {
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            },
-            "parameter_type": {
-              "$ref": "#/$defs/ToolEndpointParameterTypeInfo"
-            }
-          },
-          "required": [
-            "name",
-            "description",
-            "parameter_type"
-          ],
-          "title": "ClientToolParameterInfo",
-          "type": "object"
-        },
-        "ConditionGroup": {
-          "properties": {
-            "conditions": {
-              "items": {
-                "anyOf": [
-                  {
-                    "discriminator": {
-                      "mapping": {
-                        "eq": "#/$defs/EqualityDeploymentCondition",
-                        "match": "#/$defs/MatchDeploymentCondition",
-                        "type": "#/$defs/DeploymentTypeCondition"
-                      },
-                      "propertyName": "condition_type"
-                    },
-                    "oneOf": [
-                      {
-                        "$ref": "#/$defs/EqualityDeploymentCondition"
-                      },
-                      {
-                        "$ref": "#/$defs/MatchDeploymentCondition"
-                      },
-                      {
-                        "$ref": "#/$defs/DeploymentTypeCondition"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              },
-              "title": "Conditions",
-              "type": "array"
-            }
-          },
-          "required": [
-            "conditions"
-          ],
-          "title": "ConditionGroup",
-          "type": "object"
-        },
-        "ConfigurableSchemaArray": {
-          "properties": {
-            "type": {
-              "const": "array",
-              "title": "Type",
-              "type": "string"
-            },
-            "items": {
-              "discriminator": {
-                "mapping": {
-                  "None": "#/$defs/ConfigurableSchemaConst",
-                  "array": "#/$defs/ConfigurableSchemaArray",
-                  "boolean": "#/$defs/ConfigurableSchemaSimpleType",
-                  "integer": "#/$defs/ConfigurableSchemaSimpleType",
-                  "number": "#/$defs/ConfigurableSchemaSimpleType",
-                  "object": "#/$defs/ConfigurableSchemaObject",
-                  "string": "#/$defs/ConfigurableSchemaSimpleType"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaSimpleType"
-                },
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaConst"
-                },
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaObject"
-                },
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaArray"
-                }
-              ],
-              "title": "Items"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "items",
-            "description"
-          ],
-          "title": "ConfigurableSchemaArray",
-          "type": "object"
-        },
-        "ConfigurableSchemaConst": {
-          "properties": {
-            "type": {
-              "const": null,
-              "title": "Type",
-              "type": "null"
-            },
-            "const": {
-              "title": "Const"
-            }
-          },
-          "required": [
-            "type",
-            "const"
-          ],
-          "title": "ConfigurableSchemaConst",
-          "type": "object"
-        },
-        "ConfigurableSchemaObject": {
-          "additionalProperties": false,
-          "properties": {
-            "type": {
-              "const": "object",
-              "title": "Type",
-              "type": "string"
-            },
-            "properties": {
-              "type": "object",
-              "additionalProperties": {
-                "discriminator": {
-                  "mapping": {
-                    "None": "#/$defs/ConfigurableSchemaConst",
-                    "array": "#/$defs/ConfigurableSchemaArray",
-                    "boolean": "#/$defs/ConfigurableSchemaSimpleType",
-                    "integer": "#/$defs/ConfigurableSchemaSimpleType",
-                    "number": "#/$defs/ConfigurableSchemaSimpleType",
-                    "object": "#/$defs/ConfigurableSchemaObject",
-                    "string": "#/$defs/ConfigurableSchemaSimpleType"
-                  },
-                  "propertyName": "type"
-                },
-                "oneOf": [
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaSimpleType"
-                  },
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaConst"
-                  },
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaObject"
-                  },
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaArray"
-                  }
-                ]
-              },
-              "title": "Properties"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            },
-            "required": {
-              "anyOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Required"
-            }
-          },
-          "required": [
-            "type",
-            "properties",
-            "description"
-          ],
-          "title": "ConfigurableSchemaObject",
-          "type": "object"
-        },
-        "ConfigurableSchemaSimpleType": {
-          "properties": {
-            "type": {
-              "enum": [
-                "string",
-                "number",
-                "integer",
-                "boolean"
-              ],
-              "title": "Type",
-              "type": "string"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "description"
-          ],
-          "title": "ConfigurableSchemaSimpleType",
-          "type": "object"
-        },
-        "DeploymentTypeCondition": {
-          "properties": {
-            "condition_type": {
-              "const": "type",
-              "title": "Condition Type",
-              "type": "string"
-            },
-            "deployment_type": {
-              "$ref": "#/$defs/DeploymentTypeEnum"
-            }
-          },
-          "required": [
-            "condition_type",
-            "deployment_type"
-          ],
-          "title": "DeploymentTypeCondition",
-          "type": "object"
-        },
-        "DeploymentTypeEnum": {
-          "enum": [
-            "application",
-            "model"
-          ],
-          "title": "DeploymentTypeEnum",
-          "type": "string"
-        },
-        "EqualityDeploymentCondition": {
-          "properties": {
-            "condition_type": {
-              "const": "eq",
-              "title": "Condition Type",
-              "type": "string"
-            },
-            "property_name": {
-              "$ref": "#/$defs/PropertyEnum"
-            },
-            "const": {
-              "title": "Const",
-              "type": "string"
-            }
-          },
-          "required": [
-            "condition_type",
-            "property_name",
-            "const"
-          ],
-          "title": "EqualityDeploymentCondition",
-          "type": "object"
-        },
-        "MatchDeploymentCondition": {
-          "properties": {
-            "condition_type": {
-              "const": "match",
-              "title": "Condition Type",
-              "type": "string"
-            },
-            "property_name": {
-              "$ref": "#/$defs/PropertyEnum"
-            },
-            "expression": {
-              "title": "Expression",
-              "type": "string"
-            }
-          },
-          "required": [
-            "condition_type",
-            "property_name",
-            "expression"
-          ],
-          "title": "MatchDeploymentCondition",
-          "type": "object"
-        },
-        "OpenAiToolConfig_RestApiEndpointObjectParam_RestApiEndpointArrayParam_RestApiEndpointSimpleTypeParam_RestApiEndpointConstParam_": {
-          "properties": {
-            "type": {
-              "const": "function",
-              "default": "function",
-              "title": "Type",
-              "type": "string"
-            },
-            "function": {
-              "$ref": "#/$defs/OpenAiToolFunction_RestApiEndpointSimpleTypeParam_RestApiEndpointConstParam_RestApiEndpointObjectParam_RestApiEndpointArrayParam_"
-            }
-          },
-          "required": [
-            "function"
-          ],
-          "title": "OpenAiToolConfig[RestApiEndpointObjectParam, RestApiEndpointArrayParam, RestApiEndpointSimpleTypeParam, RestApiEndpointConstParam]",
-          "type": "object"
-        },
-        "OpenAiToolFunctionParameters_RestApiEndpointSimpleTypeParam_RestApiEndpointConstParam_RestApiEndpointObjectParam_RestApiEndpointArrayParam_": {
-          "properties": {
-            "type": {
-              "const": "object",
-              "title": "Type",
-              "type": "string"
-            },
-            "properties": {
-              "type": "object",
-              "additionalProperties": {
-                "discriminator": {
-                  "mapping": {
-                    "None": "#/$defs/RestApiEndpointConstParam",
-                    "array": "#/$defs/RestApiEndpointArrayParam",
-                    "boolean": "#/$defs/RestApiEndpointSimpleTypeParam",
-                    "integer": "#/$defs/RestApiEndpointSimpleTypeParam",
-                    "number": "#/$defs/RestApiEndpointSimpleTypeParam",
-                    "object": "#/$defs/RestApiEndpointObjectParam",
-                    "string": "#/$defs/RestApiEndpointSimpleTypeParam"
-                  },
-                  "propertyName": "type"
-                },
-                "oneOf": [
-                  {
-                    "$ref": "#/$defs/RestApiEndpointSimpleTypeParam"
-                  },
-                  {
-                    "$ref": "#/$defs/RestApiEndpointConstParam"
-                  },
-                  {
-                    "$ref": "#/$defs/RestApiEndpointObjectParam"
-                  },
-                  {
-                    "$ref": "#/$defs/RestApiEndpointArrayParam"
-                  }
-                ]
-              },
-              "title": "Properties"
-            },
-            "required": {
-              "anyOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Required"
-            }
-          },
-          "required": [
-            "type",
-            "properties"
-          ],
-          "title": "OpenAiToolFunctionParameters[RestApiEndpointSimpleTypeParam, RestApiEndpointConstParam, RestApiEndpointObjectParam, RestApiEndpointArrayParam]",
-          "type": "object"
-        },
-        "OpenAiToolFunction_RestApiEndpointSimpleTypeParam_RestApiEndpointConstParam_RestApiEndpointObjectParam_RestApiEndpointArrayParam_": {
-          "properties": {
-            "parameters": {
-              "$ref": "#/$defs/OpenAiToolFunctionParameters_RestApiEndpointSimpleTypeParam_RestApiEndpointConstParam_RestApiEndpointObjectParam_RestApiEndpointArrayParam_"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "parameters",
-            "description",
-            "name"
-          ],
-          "title": "OpenAiToolFunction[RestApiEndpointSimpleTypeParam, RestApiEndpointConstParam, RestApiEndpointObjectParam, RestApiEndpointArrayParam]",
-          "type": "object"
-        },
-        "PropertyEnum": {
-          "enum": [
-            "display_name",
-            "description",
-            "application",
-            "id"
-          ],
-          "title": "PropertyEnum",
-          "type": "string"
-        },
-        "RestApiEndpointArrayParam": {
-          "properties": {
-            "parameter_info": {
-              "$ref": "#/$defs/RestApiEndpointHeaderParamInfo"
-            },
-            "type": {
-              "const": "array",
-              "title": "Type",
-              "type": "string"
-            },
-            "items": {
-              "discriminator": {
-                "mapping": {
-                  "None": "#/$defs/ConfigurableSchemaConst",
-                  "array": "#/$defs/ConfigurableSchemaArray",
-                  "boolean": "#/$defs/ConfigurableSchemaSimpleType",
-                  "integer": "#/$defs/ConfigurableSchemaSimpleType",
-                  "number": "#/$defs/ConfigurableSchemaSimpleType",
-                  "object": "#/$defs/ConfigurableSchemaObject",
-                  "string": "#/$defs/ConfigurableSchemaSimpleType"
-                },
-                "propertyName": "type"
-              },
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaSimpleType"
-                },
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaConst"
-                },
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaObject"
-                },
-                {
-                  "$ref": "#/$defs/ConfigurableSchemaArray"
-                }
-              ],
-              "title": "Items"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            }
-          },
-          "required": [
-            "parameter_info",
-            "type",
-            "items",
-            "description"
-          ],
-          "title": "RestApiEndpointArrayParam",
-          "type": "object"
-        },
-        "RestApiEndpointConstParam": {
-          "properties": {
-            "parameter_info": {
-              "$ref": "#/$defs/RestApiEndpointHeaderParamInfo"
-            },
-            "type": {
-              "const": null,
-              "title": "Type",
-              "type": "null"
-            },
-            "const": {
-              "title": "Const"
-            }
-          },
-          "required": [
-            "parameter_info",
-            "type",
-            "const"
-          ],
-          "title": "RestApiEndpointConstParam",
-          "type": "object"
-        },
-        "RestApiEndpointHeaderParamInfo": {
-          "properties": {
-            "type": {
-              "$ref": "#/$defs/ToolEndpointParamType"
-            },
-            "key": {
-              "title": "Key",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "key"
-          ],
-          "title": "RestApiEndpointHeaderParamInfo",
-          "type": "object"
-        },
-        "RestApiEndpointMethodInfo": {
-          "properties": {
-            "method_url": {
-              "title": "Method Url",
-              "type": "string"
-            },
-            "method_type": {
-              "$ref": "#/$defs/ToolEndpointInfoMethodType"
-            }
-          },
-          "required": [
-            "method_url",
-            "method_type"
-          ],
-          "title": "RestApiEndpointMethodInfo",
-          "type": "object"
-        },
-        "RestApiEndpointObjectParam": {
-          "additionalProperties": false,
-          "properties": {
-            "parameter_info": {
-              "$ref": "#/$defs/RestApiEndpointHeaderParamInfo"
-            },
-            "type": {
-              "const": "object",
-              "title": "Type",
-              "type": "string"
-            },
-            "properties": {
-              "type": "object",
-              "additionalProperties": {
-                "discriminator": {
-                  "mapping": {
-                    "None": "#/$defs/ConfigurableSchemaConst",
-                    "array": "#/$defs/ConfigurableSchemaArray",
-                    "boolean": "#/$defs/ConfigurableSchemaSimpleType",
-                    "integer": "#/$defs/ConfigurableSchemaSimpleType",
-                    "number": "#/$defs/ConfigurableSchemaSimpleType",
-                    "object": "#/$defs/ConfigurableSchemaObject",
-                    "string": "#/$defs/ConfigurableSchemaSimpleType"
-                  },
-                  "propertyName": "type"
-                },
-                "oneOf": [
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaSimpleType"
-                  },
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaConst"
-                  },
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaObject"
-                  },
-                  {
-                    "$ref": "#/$defs/ConfigurableSchemaArray"
-                  }
-                ]
-              },
-              "title": "Properties"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            },
-            "required": {
-              "anyOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Required"
-            }
-          },
-          "required": [
-            "parameter_info",
-            "type",
-            "properties",
-            "description"
-          ],
-          "title": "RestApiEndpointObjectParam",
-          "type": "object"
-        },
-        "RestApiEndpointSimpleTypeParam": {
-          "properties": {
-            "parameter_info": {
-              "$ref": "#/$defs/RestApiEndpointHeaderParamInfo"
-            },
-            "type": {
-              "enum": [
-                "string",
-                "number",
-                "integer",
-                "boolean"
-              ],
-              "title": "Type",
-              "type": "string"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            }
-          },
-          "required": [
-            "parameter_info",
-            "type",
-            "description"
-          ],
-          "title": "RestApiEndpointSimpleTypeParam",
-          "type": "object"
-        },
-        "RestApiTool": {
-          "properties": {
-            "open_ai_tool": {
-              "$ref": "#/$defs/OpenAiToolConfig_RestApiEndpointObjectParam_RestApiEndpointArrayParam_RestApiEndpointSimpleTypeParam_RestApiEndpointConstParam_"
-            },
-            "rest_api_method_info": {
-              "$ref": "#/$defs/RestApiEndpointMethodInfo"
-            }
-          },
-          "required": [
-            "open_ai_tool",
-            "rest_api_method_info"
-          ],
-          "title": "RestApiTool",
-          "type": "object"
-        },
-        "RestApiToolset": {
-          "properties": {
-            "type": {
-              "const": "rest-api",
-              "default": "rest-api",
-              "description": "The type of the tool set.",
-              "title": "Type",
-              "type": "string"
-            },
-            "authorization": {
-              "anyOf": [
-                {
-                  "discriminator": {
-                    "mapping": {
-                      "api_key": "#/$defs/ApiKeyAuthorization",
-                      "basic": "#/$defs/BasicAuthorization",
-                      "bearer": "#/$defs/BearerAuthorization",
-                      "client_id_secret": "#/$defs/ClientIdSecretAuthorization"
-                    },
-                    "propertyName": "type"
-                  },
-                  "oneOf": [
-                    {
-                      "$ref": "#/$defs/BasicAuthorization"
-                    },
-                    {
-                      "$ref": "#/$defs/BearerAuthorization"
-                    },
-                    {
-                      "$ref": "#/$defs/ClientIdSecretAuthorization"
-                    },
-                    {
-                      "$ref": "#/$defs/ApiKeyAuthorization"
-                    }
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            },
-            "tools": {
-              "items": {
-                "$ref": "#/$defs/RestApiTool"
-              },
-              "title": "Tools",
-              "type": "array"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "authorization",
-            "tools",
-            "name"
-          ],
-          "title": "RestApiToolset",
-          "type": "object"
-        },
-        "ToolEndpointInfo": {
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "method_url": {
-              "title": "Method Url",
-              "type": "string"
-            },
-            "method_type": {
-              "$ref": "#/$defs/ToolEndpointInfoMethodType"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            },
-            "parameters": {
-              "items": {
-                "$ref": "#/$defs/ToolEndpointParameterInfo"
-              },
-              "title": "Parameters",
-              "type": "array"
-            }
-          },
-          "required": [
-            "name",
-            "method_url",
-            "method_type",
-            "description",
-            "parameters"
-          ],
-          "title": "ToolEndpointInfo",
-          "type": "object"
-        },
-        "ToolEndpointInfoMethodType": {
-          "enum": [
-            "get",
-            "post",
-            "put",
-            "delete"
-          ],
-          "title": "ToolEndpointInfoMethodType",
-          "type": "string"
-        },
-        "ToolEndpointParamType": {
-          "enum": [
-            "query",
-            "url",
-            "body",
-            "header"
-          ],
-          "title": "ToolEndpointParamType",
-          "type": "string"
-        },
-        "ToolEndpointParameterInfo": {
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "description": {
-              "title": "Description",
-              "type": "string"
-            },
-            "url_param": {
-              "default": false,
-              "title": "Url Param",
-              "type": "boolean"
-            },
-            "constant_value": {
-              "default": null,
-              "title": "Constant Value"
-            },
-            "parameter_type": {
-              "$ref": "#/$defs/ToolEndpointParameterTypeInfo"
-            },
-            "item_parameter_type": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ToolEndpointParameterTypeInfo"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null
-            },
-            "item_descriptor": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Item Descriptor"
-            }
-          },
-          "required": [
-            "name",
-            "description",
-            "parameter_type"
-          ],
-          "title": "ToolEndpointParameterInfo",
-          "type": "object"
-        },
-        "ToolEndpointParameterTypeInfo": {
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "object",
-            "array",
-            "boolean"
-          ],
-          "title": "ToolEndpointParameterTypeInfo",
-          "type": "string"
-        },
-        "WebApiToolsetInfo": {
-          "properties": {
-            "tool_endpoints": {
-              "items": {
-                "$ref": "#/$defs/ToolEndpointInfo"
-              },
-              "title": "Tool Endpoints",
-              "type": "array"
-            },
-            "auth_info": {
-              "anyOf": [
-                {
-                  "discriminator": {
-                    "mapping": {
-                      "apikey": "#/$defs/WebApiToolsetKeyAuthInfo",
-                      "obo": "#/$defs/WebApiToolsetOBOAuthInfo"
-                    },
-                    "propertyName": "auth_type"
-                  },
-                  "oneOf": [
-                    {
-                      "$ref": "#/$defs/WebApiToolsetOBOAuthInfo"
-                    },
-                    {
-                      "$ref": "#/$defs/WebApiToolsetKeyAuthInfo"
-                    }
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Auth Info"
-            }
-          },
-          "required": [
-            "tool_endpoints",
-            "auth_info"
-          ],
-          "title": "WebApiToolsetInfo",
-          "type": "object"
-        },
-        "WebApiToolsetKeyAuthInfo": {
-          "properties": {
-            "auth_type": {
-              "const": "apikey",
-              "title": "Auth Type",
-              "type": "string"
-            },
-            "api_key": {
-              "format": "password",
-              "title": "Api Key",
-              "type": "string",
-              "writeOnly": true
-            },
-            "url_param": {
-              "default": false,
-              "title": "Url Param",
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "auth_type",
-            "api_key"
-          ],
-          "title": "WebApiToolsetKeyAuthInfo",
-          "type": "object"
-        },
-        "WebApiToolsetOBOAuthInfo": {
-          "properties": {
-            "auth_type": {
-              "const": "obo",
-              "title": "Auth Type",
-              "type": "string"
-            },
-            "tenant": {
-              "title": "Tenant",
-              "type": "string"
-            },
-            "grant_type": {
-              "title": "Grant Type",
-              "type": "string"
-            },
-            "client_id": {
-              "title": "Client Id",
-              "type": "string"
-            },
-            "client_secret": {
-              "format": "password",
-              "title": "Client Secret",
-              "type": "string",
-              "writeOnly": true
-            },
-            "scope": {
-              "title": "Scope",
-              "type": "string"
-            },
-            "assertion": {
-              "title": "Assertion",
-              "type": "string"
-            }
-          },
-          "required": [
-            "auth_type",
-            "tenant",
-            "grant_type",
-            "client_id",
-            "client_secret",
-            "scope",
-            "assertion"
-          ],
-          "title": "WebApiToolsetOBOAuthInfo",
-          "type": "object"
-        },
-        "MCPApiKeyAuthorization": {
-          "properties": {
-            "type": {
-              "const": "api_key",
-              "default": "api_key",
-              "title": "Type",
-              "type": "string"
-            },
-            "key": {
-              "title": "Key",
-              "type": "string"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "key",
-            "name"
-          ],
-          "title": "MCPApiKeyAuthorization",
-          "type": "object"
-        },
-        "MCPServerInfo": {
-          "properties": {
-            "url": {
-              "description": "URL of the MCP server",
-              "title": "Url",
-              "type": "string"
-            },
-            "protocol": {
-              "$ref": "#/$defs/MCPProtocol"
-            },
-            "authorization": {
-              "anyOf": [
-                {
-                  "discriminator": {
-                    "mapping": {
-                      "api_key": "#/$defs/MCPApiKeyAuthorization",
-                      "basic": "#/$defs/BasicAuthorization",
-                      "bearer": "#/$defs/BearerAuthorization",
-                      "client_id_secret": "#/$defs/ClientIdSecretAuthorization"
-                    },
-                    "propertyName": "type"
-                  },
-                  "oneOf": [
-                    {
-                      "$ref": "#/$defs/BearerAuthorization"
-                    },
-                    {
-                      "$ref": "#/$defs/MCPApiKeyAuthorization"
-                    },
-                    {
-                      "$ref": "#/$defs/ClientIdSecretAuthorization"
-                    },
-                    {
-                      "$ref": "#/$defs/BasicAuthorization"
-                    }
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Authorization"
-            }
-          },
-          "required": [
-            "url",
-            "protocol"
-          ],
-          "title": "MCPServerInfo",
-          "type": "object"
-        },
-        "MCPToolsetInfo": {
-          "properties": {
-            "name": {
-              "description": "The name of the tool set.",
-              "title": "Name",
-              "type": "string"
-            },
-            "type": {
-              "const": "mcp",
-              "default": "mcp",
-              "description": "The type of the tool set.",
-              "title": "Type",
-              "type": "string"
-            },
-            "mcp_server_info": {
-              "$ref": "#/$defs/MCPServerInfo"
-            },
-            "allowed_tools": {
-              "anyOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Allowed MCP tool names from the server",
-              "title": "Allowed Tools"
-            }
-          },
-          "required": [
-            "name",
-            "mcp_server_info"
-          ],
-          "title": "MCPToolsetInfo",
-          "type": "object"
-        },
-        "MCPProtocol": {
-          "enum": [
-          "sse",
-          "streamable_http"
-          ],
-        "title": "MCPProtocol",
-        "type": "string"
-        }
-      },
-      "properties": {
-        "temperature": {
-          "title": "Temperature",
-          "type": "number",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 1
-          }
-        },
-        "instructions": {
-          "title": "Instructions",
-          "type": "string",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 2
-          }
-        },
-        "model": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ConditionGroup"
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "title": "Model",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 3
-          }
-        },
-        "web_api_toolset": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/WebApiToolsetInfo"
-              },
-              {
-                "$ref": "#/$defs/RestApiToolset"
-              }
-            ]
-          },
-          "title": "Web Api Toolset",
-          "type": "array",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 4
-          }
-        },
-        "document_relative_url": {
-          "oneOf": [
-            {
-              "type": "string",
-              "format": "dial-file-encoded",
-              "dial:file": true
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "dial:file": true,
-                "format": "dial-file-encoded"
-              }
-            }
-          ],
-          "default": null,
-          "title": "Document Relative Url",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 5
-          }
-        },
-        "starters": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Starters",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 6
-          }
-        },
-        "applications_as_tools": {
-          "anyOf": [
-            {
-              "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/ConditionGroup"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Applications As Tools",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 7
-          }
-        },
-        "attachments_in_stage": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Attachments In Stage",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 8
-          }
-        },
-        "client_toolset": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/ClientToolInfo"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Client Toolset",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 9
-          }
-        },
-        "mcp_toolset": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/MCPToolsetInfo"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Mcp Toolset",
-          "dial:meta": {
-            "dial:propertyKind": "server",
-            "dial:propertyOrder": 10
+          "dial:attachmentPaths": {
+            "dial:requestBody": ["@.url"]
           }
         }
       },
-      "required": [
-        "temperature",
-        "instructions",
-        "model",
-        "web_api_toolset"
-      ],
-      "title": "QuickAppInfo",
-      "type": "object"
+      "$id": "https://mydial.epam.com/custom_application_schemas/quickapps2",
+      "$schema": "https://dial.epam.com/application_type_schemas/schema#"
     }
   ]
 }
 ```
+
+What each field does:
+
+* **`dial:applicationTypeCompletionEndpoint`** — where DIAL Core sends chat completion requests.
+* **`dial:applicationTypeConfigurationEndpoint`** — where DIAL Core pulls each app instance's
+  configuration, including starter buttons.
+* **`dial:applicationTypeSchemaEndpoint`** — where DIAL Core fetches the live configuration schema
+  that powers the editor UI and validation. This keeps the schema in sync with the deployed service
+  version automatically.
+* **`dial:applicationTypeRoutes`** — exposes the service's `/v1/configuration-support/*` endpoints
+  (used by the editor to list predefined skills, prompts, tool sets and tools) to DIAL clients
+  through DIAL Core. Both entries are `WRITE`-gated since configuration support is only useful to
+  callers with edit access.
+* **`$id`** — the application type's identifier. Use exactly
+  `https://mydial.epam.com/custom_application_schemas/quickapps2`: DIAL Chat recognizes Quick Apps 2.0
+  (and opens the 2.0 editor) by this specific id, so it must match.
+
+## Step 4: Configure DIAL Core to Include Custom Applications
+
+Set the following DIAL Core environment variable so end-users can create their own Quick Apps 2.0
+instances:
+
+```yaml
+aidial.applications.includeCustomApps: "true"
+```
+
+## Step 5: DIAL Chat Configuration
+
+Add `quick-apps` to `ENABLED_FEATURES` so the Quick Apps 2.0 editor is available in DIAL Chat:
+
+```yaml
+ENABLED_FEATURES: "...,quick-apps"
+```
+
+That is all that is required. DIAL Chat recognizes a Quick Apps 2.0 application — and opens the 2.0
+editor for it — by the application type's `$id`
+(`https://mydial.epam.com/custom_application_schemas/quickapps2`, set in [Step 3](#step-3-register-the-application-type-in-dial-core)).
+
+> [!WARNING]
+> `QUICK_APPS_HOST`, `QUICK_APPS_SCHEMA_ID`, and `QUICK_APPS_MODEL` are legacy settings for the original
+> Quick Apps (1.0) and should be left unset for Quick Apps 2.0. In particular, do **not** point
+> `QUICK_APPS_SCHEMA_ID` at the 2.0 id — DIAL Chat would then open the old Quick Apps editor instead of
+> the 2.0 editor. The default orchestrator model for new Quick Apps 2.0 instances comes from the backend
+> schema (`DEFAULT_ORCHESTRATOR_DEPLOYMENT_ID`, [Step 2](#step-2-deploy-quick-apps-20-with-helm)).


### PR DESCRIPTION
### Applicable issues

N/A

### Description of changes

Rewrites the Quick Apps deployment guide, which still documented the legacy closed-source Quick Apps, to cover the open-source **Quick Apps 2.0** (`ai-dial-quickapps-backend`). Nearly every concrete value in the old guide (image registry, versions, environment variables, application-type schema, DIAL Chat wiring) was outdated.

Key updates:

- **Reframes the product** as the open-source agent composer, clarifying its two parts: the standalone backend runtime and the no-code configurator that ships with DIAL Chat (so editor features track the DIAL Chat version).
- **Refreshes component versions** to the DIAL `1.44` line (quickapps-backend `0.8.0`, DIAL Core `0.44.0`, DIAL Chat `0.46.0`), noting the DIAL Core `0.41.0` floor for the application-type schema endpoint.
- **Fixes the image** — replaces the dead `registry.deltixhub.com` reference with the public `ghcr.io/epam/ai-dial-quickapps-backend` image and a minimal, accurate Helm `values.yaml`.
- **Rewrites the DIAL Core registration** to the current `quickapps2` application type using the recommended schema endpoint plus `dial:applicationTypeRoutes`, with a field-by-field explanation; links the backend's `application-schema.md`.
- **Corrects DIAL Chat setup** — only `quick-apps` in `ENABLED_FEATURES` is required. Adds a warning that the legacy `QUICK_APPS_*` env vars (Quick Apps 1.0) must stay unset: pointing `QUICK_APPS_SCHEMA_ID` at the 2.0 id forces DIAL Chat to load the old editor.
- **Removes the ~1,400-line inlined application schema** (now served live from the backend) in favor of links to the maintained sources (`CONFIGURATION.md`, `application-schema.md`).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
