### PR TITLE
docs(n8n): refresh integration guide for current node-cli tooling

### DIFF
--- a/docs_v2/3.building-with-dial/6.integrations/3.workflow-automation/1.n8n.md
+++ b/docs_v2/3.building-with-dial/6.integrations/3.workflow-automation/1.n8n.md
@@ -3,7 +3,7 @@ title: "Integration with n8n"
 type: how-to
 persona: app-dev
 component: integrations
-last_verified: 2026-05-30
+last_verified: 2026-07-29
 owner: "@dial-docs-team"
 ---
 
@@ -16,39 +16,90 @@ This guide shows you how to build a custom [n8n](https://n8n.io/) node that call
 
 ## Prerequisites
 
-- n8n installed and set up, locally or in the cloud. See n8n's [installation guide](https://docs.n8n.io/hosting/installation/npm/).
+- Node.js 22.22.0+ installed locally, and npm, for building and testing the node.
 - A DIAL API key for authentication.
-- Node.js installed locally for building and testing the node.
 - A running [DIAL Core](https://dialx.ai/) instance reachable from your n8n environment.
+- n8n installed and set up, locally or in the cloud. See n8n's [install options](https://docs.n8n.io/deploy/host-n8n/install-options).
 
 ## Build the DIAL custom node
 
-n8n organizes workflows using [nodes](https://docs.n8n.io/workflows/components/nodes/) — building blocks that perform a specific action, such as calling an API, transforming data, or running a script. Built-in nodes do not cover DIAL, so you build a [custom node](https://docs.n8n.io/integrations/creating-nodes/overview/) that calls the Unified API.
+n8n organizes workflows using [nodes](https://docs.n8n.io/build/understand-workflows/workflow-components/work-with-nodes) — building blocks that perform a specific action, such as calling an API, transforming data, or running a script. Built-in nodes do not cover DIAL, so you build a [custom node](https://docs.n8n.io/connect/create-nodes/overview) that calls the Unified API.
 
 ### Step 1: Plan the node
 
 Design the DIAL custom node as follows:
 
-- Type — [action node](https://docs.n8n.io/integrations/creating-nodes/plan/node-types/#action-nodes).
-- Building approach — [declarative style](https://docs.n8n.io/integrations/creating-nodes/plan/choose-node-method/).
-- UI components — [credentials, operations, and fields](https://docs.n8n.io/integrations/creating-nodes/plan/node-ui-design/#credentials).
-- File structure — follow n8n's [node file structure](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-file-structure/).
+- Type — [action node](https://docs.n8n.io/connect/create-nodes/plan-your-node/choose-a-node-type#action-nodes).
+- Building approach — [programmatic style](https://docs.n8n.io/connect/create-nodes/plan-your-node/choose-a-node-building-style).
+- UI components — [credentials, operations, and fields](https://docs.n8n.io/connect/create-nodes/plan-your-node/node-ui-design#credentials).
+- File structure — follow n8n's [node file structure guidance](https://docs.n8n.io/connect/create-nodes/plan-your-node/choose-node-file-structure).
 
 ### Step 2: Build the node
 
-Set up a [development environment](https://docs.n8n.io/integrations/creating-nodes/build/node-development-environment/) first, then build and test the node.
+Set up a [development environment](https://docs.n8n.io/connect/create-nodes/build-your-node/set-up-your-development-environment) first, then build and test the node.
 
-1. Fetch the [n8n node starter template](https://github.com/n8n-io/n8n-nodes-starter) and remove the examples from the `/nodes` and `/credentials` folders.
-2. Create a [credentials file](https://docs.n8n.io/integrations/creating-nodes/build/declarative-style-node/#step-4-set-up-authentication) named `DialApi.credentials.ts` in the `/credentials` directory with the following code:
+n8n's official [`@n8n/node-cli`](https://docs.n8n.io/connect/create-nodes/build-your-node/using-the-n8n-node-tool/) tool scaffolds, lints, builds, and locally test-runs community nodes.
+
+1. Scaffold a new node project:
+
+   ```shell
+   npm create @n8n/node@latest
+   ```
+
+   When prompted, name the project `n8n-nodes-dial` and choose the **programmatic** template with **basic** type. This generates a working project with the following layout:
+
+   ```text
+   n8n-nodes-dial/
+   ├── nodes/
+   │   └── Example/
+   │       ├── Example.node.ts
+   │       ├── Example.node.json
+   │       ├── example.svg
+   │       └── example.dark.svg
+   ├── package.json
+   └── tsconfig.json
+   ```
+
+2. Rename the example node to `Dial`:
+
+   ```shell
+   cd n8n-nodes-dial
+   mv nodes/Example nodes/Dial
+   mv nodes/Dial/Example.node.ts nodes/Dial/Dial.node.ts
+   mv nodes/Dial/Example.node.json nodes/Dial/Dial.node.json
+   mv nodes/Dial/example.svg nodes/Dial/dial.svg
+   mv nodes/Dial/example.dark.svg nodes/Dial/dial.dark.svg
+   ```
+
+3. Create the [credentials](https://docs.n8n.io/connect/create-nodes/build-your-node/tutorial-build-a-programmatic-style-node#step-5-set-up-authentication) folder and file. CLI doesn't scaffold credentials for the programmatic template, so add it yourself:
+
+   ```shell
+   mkdir credentials
+   ```
+
+   Create `credentials/DialApi.credentials.ts` with the following code:
 
    ```typescript
-   import { ICredentialType, INodeProperties } from 'n8n-workflow';
+   import {
+     IAuthenticateGeneric,
+     ICredentialType,
+     INodeProperties,
+   } from 'n8n-workflow';
 
    export class DialApi implements ICredentialType {
      name = 'dialApi';
      displayName = 'DIAL API';
-     documentationUrl = 'https://<URL_TO_API_KEY_DOCS>/';
+     documentationUrl = 'https://docs.dialx.ai/';
      properties: INodeProperties[] = [
+       {
+         displayName: 'Base URL',
+         name: 'baseUrl',
+         type: 'string',
+         default: '',
+         required: true,
+         placeholder: 'https://your-dial-deployment.example.com',
+         description: 'The base URL of your DIAL Core deployment.',
+       },
        {
          displayName: 'API Key',
          name: 'apiKey',
@@ -61,14 +112,23 @@ Set up a [development environment](https://docs.n8n.io/integrations/creating-nod
          description: 'The API key for DIAL.',
        },
      ];
+
+     authenticate: IAuthenticateGeneric = {
+       type: 'generic',
+       properties: {
+         headers: {
+           'Api-Key': '={{$credentials.apiKey}}',
+         },
+       },
+     };
    }
    ```
 
-3. Create a [metadata file](https://docs.n8n.io/integrations/creating-nodes/build/declarative-style-node/#step-5-add-node-metadata) named `Dial.node.json` in the `/nodes` directory with the following code:
+3. Replace the [metadata file](https://docs.n8n.io/connect/create-nodes/build-your-node/tutorial-build-a-programmatic-style-node#step-6-add-node-metadata) named `Dial.node.json` in the `/nodes` directory with the following code:
 
    ```json
    {
-     "node": "n8n-nodes-base.dial",
+     "node": "n8n-nodes-dial",
      "nodeVersion": "1.0",
      "codexVersion": "1.0",
      "categories": ["Miscellaneous"],
@@ -87,16 +147,18 @@ Set up a [development environment](https://docs.n8n.io/integrations/creating-nod
    }
    ```
 
-4. Create a [node file](https://docs.n8n.io/integrations/creating-nodes/build/declarative-style-node/#step-3-create-the-node) named `Dial.node.ts` in the `/nodes` directory with the following code. Replace each placeholder (`<...>`) with your own values, and adjust the logic to fit your needs.
+4. Replace the [node file](https://docs.n8n.io/connect/create-nodes/build-your-node/tutorial-build-a-programmatic-style-node#step-3-define-the-node-in-the-base-file) named `Dial.node.ts` in the `/nodes` directory with the following code. Adjust the logic to fit your needs.
 
    ```typescript
-   import {
+   import type {
+     IDataObject,
+     IExecuteFunctions,
+     IHttpRequestOptions,
+     INodeExecutionData,
      INodeType,
      INodeTypeDescription,
-     INodeExecutionData,
-     IExecuteFunctions,
-     IDataObject,
    } from 'n8n-workflow';
+   import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
    export class Dial implements INodeType {
      description: INodeTypeDescription = {
@@ -108,31 +170,17 @@ Set up a [development environment](https://docs.n8n.io/integrations/creating-nod
        defaults: {
          name: 'DIAL API',
        },
-       icon: 'file:favicon.png',
-       inputs: ['main'],
-       outputs: ['main'],
+       icon: { light: 'file:dial.svg', dark: 'file:dial.dark.svg' },
+       inputs: [NodeConnectionTypes.Main],
+       outputs: [NodeConnectionTypes.Main],
+       usableAsTool: true,
        credentials: [
          {
            name: 'dialApi',
            required: true,
          },
        ],
-       requestDefaults: {
-         baseURL: '<URL_TO_YOUR_DIAL_DEPLOYMENT>',
-         headers: {
-           Accept: 'application/json',
-           'Content-Type': 'application/json',
-         },
-       },
        properties: [
-         {
-           displayName: 'User Input',
-           name: 'userInput',
-           type: 'string',
-           default: '',
-           required: true,
-           description: "The user's request to gather data.",
-         },
          {
            displayName: 'Operation',
            name: 'operation',
@@ -152,64 +200,106 @@ Set up a [development environment](https://docs.n8n.io/integrations/creating-nod
            default: 'chatCompletion',
            description: 'Choose the DIAL operation to perform',
          },
+         {
+           displayName: 'Deployment Name',
+           name: 'deploymentName',
+           type: 'string',
+           default: 'gpt-4',
+           required: true,
+           description: 'The name of the DIAL model deployment to call, for example gpt-4 or text-embedding-ada-002',
+         },
+         {
+           displayName: 'API Version',
+           name: 'apiVersion',
+           type: 'string',
+           default: '2024-02-01',
+           required: true,
+           description: 'The DIAL/OpenAI API version to use',
+         },
+         {
+           displayName: 'User Input',
+           name: 'userInput',
+           type: 'string',
+           default: '',
+           required: true,
+           description: 'The text to send to the selected operation: the chat message for Chat Completion, or the text to embed for Text Embeddings',
+         },
        ],
      };
 
      async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-       const credentials = await this.getCredentials('dialApi');
+       const items = this.getInputData();
+       const returnData: INodeExecutionData[] = [];
 
-       const apiKey = credentials.apiKey as string;
-       const userInput = this.getNodeParameter('userInput', 0) as string;
-       const operation = this.getNodeParameter('operation', 0) as string;
+       for (let i = 0; i < items.length; i++) {
+         try {
+           const operation = this.getNodeParameter('operation', i) as string;
+           const deploymentName = this.getNodeParameter('deploymentName', i) as string;
+           const apiVersion = this.getNodeParameter('apiVersion', i) as string;
+           const userInput = this.getNodeParameter('userInput', i) as string;
 
-       const baseUrl = `<URL_TO_YOUR_DIAL_DEPLOYMENT>`;
-       const apiVersion = '<MODEL_VERSION e.g. 2023-12-01-preview>';
+           const credentials = await this.getCredentials('dialApi');
+           const baseUrl = credentials.baseUrl as string;
 
-       let responseData: IDataObject;
-       if (operation === 'chatCompletion') {
-         // Chat completion endpoint
-         const endpointUrl = `${baseUrl}/openai/deployments/gpt-4/chat/completions?api-version=${apiVersion}`;
-         const body = {
-           messages: [{ role: 'user', content: userInput }],
-         };
+           let options: IHttpRequestOptions;
 
-         responseData = await this.helpers.request({
-           method: 'POST',
-           url: endpointUrl,
-           headers: {
-             'Content-Type': 'application/json',
-             'Api-Key': apiKey,
-           },
-           body,
-           json: true,
-         });
-       } else if (operation === 'textEmbedding') {
-         // Text embedding endpoint
-         const endpointUrl = `${baseUrl}/openai/deployments/text-embedding-ada-002/embeddings?api-version=${apiVersion}`;
-         const body = {
-           input: userInput,
-         };
+           if (operation === 'chatCompletion') {
+             options = {
+               method: 'POST',
+               url: `${baseUrl}/openai/deployments/${deploymentName}/chat/completions`,
+               qs: { 'api-version': apiVersion },
+               body: {
+                 messages: [{ role: 'user', content: userInput }],
+               },
+               json: true,
+             };
+           } else if (operation === 'textEmbedding') {
+             options = {
+               method: 'POST',
+               url: `${baseUrl}/openai/deployments/${deploymentName}/embeddings`,
+               qs: { 'api-version': apiVersion },
+               body: {
+                 input: userInput,
+               },
+               json: true,
+             };
+           } else {
+             throw new NodeOperationError(this.getNode(), `Unsupported operation: ${operation}`, {
+               itemIndex: i,
+             });
+           }
 
-         responseData = await this.helpers.request({
-           method: 'POST',
-           url: endpointUrl,
-           headers: {
-             'Content-Type': 'application/json',
-             'Api-Key': apiKey,
-           },
-           body,
-           json: true,
-         });
-       } else {
-         throw new Error(`Invalid operation: ${operation}`);
+           // httpRequestWithAuthentication applies the credential's `authenticate` block above, so the Api-Key header is injected automatically.
+           const responseData = (await this.helpers.httpRequestWithAuthentication.call(
+             this,
+             'dialApi',
+             options,
+           )) as IDataObject;
+
+           const executionData = this.helpers.constructExecutionMetaData(
+             this.helpers.returnJsonArray(responseData),
+             { itemData: { item: i } },
+           );
+           returnData.push(...executionData);
+         } catch (error) {
+           if (this.continueOnFail()) {
+             const executionData = this.helpers.constructExecutionMetaData(
+               this.helpers.returnJsonArray({ error: (error as Error).message }),
+               { itemData: { item: i } },
+             );
+             returnData.push(...executionData);
+             continue;
+           }
+           throw error;
+         }
        }
 
-       return this.prepareOutputData(this.helpers.returnJsonArray([responseData]));
+       return [returnData];
      }
    }
    ```
 
-5. Update `package.json` with the following:
+5. Update `package.json`. Rename the `nodes` entry to match the renamed folder, add the `credentials` entry (the scaffold leaves this array empty), and fill in `description`, `author`, `repository`, and `homepage`:
 
    ```json
    {
@@ -227,40 +317,36 @@ Set up a [development environment](https://docs.n8n.io/integrations/creating-nod
        "type": "git",
        "url": "https://github.com/<yourcompany>/n8n-nodes-dial.git"
      },
-     "main": "index.js",
-     "scripts": {
-       "build": "tsc && gulp build:icons",
-       "dev": "tsc --watch",
-       "format": "prettier nodes credentials --write",
-       "lint": "eslint nodes credentials package.json",
-       "lintfix": "eslint nodes credentials package.json --fix",
-       "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json"
-     },
-     "files": ["dist"],
      "n8n": {
        "n8nNodesApiVersion": 1,
+       "strict": true,
        "credentials": ["dist/credentials/DialApi.credentials.js"],
        "nodes": ["dist/nodes/Dial/Dial.node.js"]
-     },
-     "devDependencies": {
-       "@types/express": "^4.17.6",
-       "@types/request-promise-native": "~1.0.15",
-       "@typescript-eslint/parser": "~5.45",
-       "eslint-plugin-n8n-nodes-base": "^1.11.0",
-       "gulp": "^4.0.2",
-       "n8n-core": "*",
-       "n8n-workflow": "*",
-       "prettier": "^2.7.1",
-       "typescript": "~4.8.4"
      }
    }
    ```
 
-6. (Optional) Add a favicon in `.png` format. See n8n's [add an icon](https://docs.n8n.io/integrations/creating-nodes/build/declarative-style-node/#step-2-add-an-icon) guide.
+   Leave `scripts` and `devDependencies` as generated by the CLI.
+
+6. (Optional) Replace `nodes/Dial/dial.svg` and `dial.dark.svg` with your own icon. See n8n's [icon reference](https://docs.n8n.io/connect/create-nodes/build-your-node/reference/base-files/standard-parameters/#icon). SVG is recommended.
+
+7. Test locally before deploying:
+
+   ```shell
+   npm run dev
+   ```
+
+   This starts a disposable n8n instance at `http://localhost:5678` with the node already linked, and rebuilds on file changes. Search for it by its `name` property (`DIAL API`), not the package name.
+
+8. Lint before you build or publish:
+
+   ```shell
+   npm run lint
+   ```
 
 ### Step 3: Deploy the node
 
-To install the node in your n8n instance, follow n8n's [install private nodes](https://docs.n8n.io/integrations/creating-nodes/deploy/install-private-nodes/) guide.
+To install the node in your production n8n instance, follow n8n's [install private nodes](https://docs.n8n.io/connect/create-nodes/deploy-your-node/install-private-nodes/) guide: run `npm run build`, then copy the compiled `nodes` and `credentials` folders from `dist` into that instance's `~/.n8n/custom/` directory (or bake them into your Docker image if you run n8n in a container).
 
 ## Use the DIAL custom node in a workflow
 
@@ -277,7 +363,7 @@ With the node installed, add it to any workflow and chain it with other n8n node
 ### Step 2: Authenticate the node
 
 1. Open the **Credentials** tab in the node configuration.
-2. Enter your DIAL API key in the credentials field. If you saved the key as a credential when you built the node, select it from the dropdown instead.
+2. Enter your DIAL deployment's base URL and API key in the credentials fields. If you saved these as a credential when you built the node, select it from the dropdown instead.
 3. Run the workflow to confirm authentication succeeds.
 
 ![Configuring credentials for the DIAL custom node](img/n8n2.png)
@@ -296,8 +382,9 @@ This example passes a user's message to DIAL and returns the model's response to
 2. Connect the trigger to the DIAL custom node and map the chat data to its input:
 
    ```text
-   User Input: {{ $json.chatInput }}
    Operation: Chat Completion
+   Deployment Name: gpt-4
+   User Input: {{ $json.chatInput }}
    ```
 
    ![Mapping chat input to the DIAL custom node](img/n8n4.png)
@@ -311,7 +398,7 @@ This example passes a user's message to DIAL and returns the model's response to
    Add a **Code** node (Python) after the DIAL custom node to reshape the output:
 
    ```python
-   return { 'output': _input.first().json.choices[0].message.content }
+   return { 'output': _input.first().json['choices'][0]['message']['content'] }
    ```
 
    ![Reshaping the DIAL response with a Code node](img/n8n5.png)


### PR DESCRIPTION
## What
Updates the n8n integration guide to match n8n's current node
development tooling and fixes several inaccuracies in the sample code.

## Why
- The old guide pointed to the retired `n8n-nodes-starter` template repo
  and used deprecated APIs
- Nearly every `docs.n8n.io` link had moved to a new URL structure
- The sample node hardcoded the DIAL deployment URL, model deployment
  name, and API version as placeholders/literals

## Changes
- Scaffold via `npm create @n8n/node@latest` (programmatic style)
  instead of cloning the old starter repo
- Update credentials to include `baseUrl` and an `authenticate` block, so the Api-Key header is injected
  automatically
- Make `Deployment Name` and `API Version` configurable node
  parameters instead of hardcoded values
- Rewrite `execute()` to loop over all input items with error handling
- Add light/dark icon support, `npm run dev` / `npm run lint` steps.
- Fix the Python Code-node snippet
- Refresh all `docs.n8n.io` links to current URL paths
- Bump `last_verified` to 2026-07-29
